### PR TITLE
Enhance author attribution in GitHub Copilot feature videos

### DIFF
--- a/_videos/ghc-features/2024-12-24-Code-Documenting.md
+++ b/_videos/ghc-features/2024-12-24-Code-Documenting.md
@@ -2,7 +2,7 @@
 layout: "post"
 title: "Code Docs"
 description: "Generate comprehensive documentation for your codebase"
-author: "Fokko"
+author: "Fokko Veegens"
 excerpt_separator: <!--excerpt_end-->
 canonical_url: "https://youtu.be/66epMMY-YUc"
 categories: ["AI", "GitHub Copilot"]

--- a/_videos/ghc-features/2024-12-24-Code-Translation.md
+++ b/_videos/ghc-features/2024-12-24-Code-Translation.md
@@ -2,7 +2,7 @@
 layout: "post"
 title: "Code Translation"
 description: "Convert code between different programming languages"
-author: "Fokko"
+author: "Fokko Veegens"
 excerpt_separator: <!--excerpt_end-->
 canonical_url: "https://youtu.be/UfQGauPcAgE"
 categories: ["AI", "GitHub Copilot"]

--- a/_videos/ghc-features/2024-12-24-atgithub-Chat-Participant.md
+++ b/_videos/ghc-features/2024-12-24-atgithub-Chat-Participant.md
@@ -2,7 +2,7 @@
 layout: "post"
 title: "@github Chat Participant"
 description: "Use Copilot as a participant in GitHub discussions"
-author: "Fokko"
+author: "Fokko Veegens"
 excerpt_separator: <!--excerpt_end-->
 canonical_url: "https://youtu.be/M_BNfo01YsQ"
 categories: ["AI", "GitHub Copilot"]

--- a/_videos/ghc-features/2025-04-04-Fetch-Webpage.md
+++ b/_videos/ghc-features/2025-04-04-Fetch-Webpage.md
@@ -2,7 +2,7 @@
 layout: "post"
 title: "Fetch Webpage"
 description: "Retrieve web pages as context for your prompts"
-author: "Fokko"
+author: "Fokko Veegens"
 excerpt_separator: <!--excerpt_end-->
 canonical_url: "https://youtu.be/UuIrbI-qX-0"
 categories: ["AI", "GitHub Copilot"]

--- a/_videos/ghc-features/2025-04-09-GPT-4o-Copilot-Suggestions-Model.md
+++ b/_videos/ghc-features/2025-04-09-GPT-4o-Copilot-Suggestions-Model.md
@@ -2,7 +2,7 @@
 layout: "post"
 title: "GPT-4o Copilot Suggestions Model"
 description: "Upgraded to GPT-4o for better code suggestions"
-author: "Fokko"
+author: "Fokko Veegens"
 excerpt_separator: <!--excerpt_end-->
 canonical_url: "https://youtu.be/zZI34xmoWbw"
 categories: ["AI", "GitHub Copilot"]

--- a/_videos/ghc-features/2025-04-09-Next-Edit-Suggestions.md
+++ b/_videos/ghc-features/2025-04-09-Next-Edit-Suggestions.md
@@ -2,7 +2,7 @@
 layout: "post"
 title: "Next Edit Suggestions"
 description: "AI predicts and suggests your next code edits"
-author: "Fokko"
+author: "Fokko Veegens"
 excerpt_separator: <!--excerpt_end-->
 canonical_url: "https://youtu.be/OZKC2c9wD1Q"
 categories: ["AI", "GitHub Copilot"]

--- a/_videos/ghc-features/2025-04-15-Agent-Mode.md
+++ b/_videos/ghc-features/2025-04-15-Agent-Mode.md
@@ -2,7 +2,7 @@
 layout: "post"
 title: "Agent Mode"
 description: "AI agent iterates and improves your prompts automatically"
-author: "Fokko"
+author: "Fokko Veegens"
 excerpt_separator: <!--excerpt_end-->
 canonical_url: "https://youtu.be/JtJ3_ATBsTY"
 categories: ["AI", "GitHub Copilot"]

--- a/_videos/ghc-features/2025-07-16-Model-selection.md
+++ b/_videos/ghc-features/2025-07-16-Model-selection.md
@@ -6,8 +6,6 @@ author: "Liuba Gonta"
 excerpt_separator: <!--excerpt_end-->
 canonical_url: "https://youtu.be/xf6i-eOnQE4"
 categories: ["AI", "GitHub Copilot", "Coding"]
-feed_name: "Rob Bos"
-feed_url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCUhUzCG4QBTMm06-zlS408A"
 date: 2025-07-16 12:45:13 +00:00
 permalink: "/2025-07-16-Model-selection.html"
 viewing_mode: "internal"


### PR DESCRIPTION
Improved content metadata consistency by standardizing author attribution to use full names instead of abbreviated versions. This change ensures proper credit is given to content creators while maintaining professional standards across our GitHub Copilot feature demonstration videos.

**Technical Changes:**
- Updated author field from "Fokko" to "Fokko Veegens" in 7 feature videos
- Removed unnecessary feed metadata from Model-selection.md 
- Standardized author attribution format across _videos/ghc-features/ collection
- Improved metadata consistency for better content organization