### PR TITLE
Fix: Sanitize invalid JSON escape sequences from AI responses

### DIFF
--- a/.github/scripts/functions/Invoke-AiApiCall.ps1
+++ b/.github/scripts/functions/Invoke-AiApiCall.ps1
@@ -242,6 +242,11 @@ function Invoke-AiApiCall {
         try {
             $responseJson = $response.Content | ConvertFrom-Json
             $contentString = $responseJson.choices[0].message.content
+            
+            # Repair invalid JSON escape sequences from AI responses (e.g., \s, \d, \w)
+            # AI models sometimes generate invalid escapes that break ConvertFrom-Json
+            $contentString = Repair-JsonResponse -JsonString $contentString
+            
             return $contentString
         }
         catch {

--- a/.github/scripts/functions/Repair-JsonResponse.ps1
+++ b/.github/scripts/functions/Repair-JsonResponse.ps1
@@ -1,0 +1,143 @@
+function Repair-JsonResponse {
+    <#
+    .SYNOPSIS
+        Repairs invalid JSON escape sequences in AI model responses.
+    
+    .DESCRIPTION
+        AI models (like GPT-4) sometimes generate invalid JSON escape sequences 
+        such as \s, \d, \w (regex patterns) or accidental backslashes before letters.
+        
+        Valid JSON escape sequences are ONLY: \" \\ \/ \b \f \n \r \t \uXXXX
+        
+        This function fixes invalid escapes by converting them to valid JSON:
+        - \s becomes \\s (escaped backslash)
+        - \d becomes \\d (escaped backslash)
+        - etc.
+    
+    .PARAMETER JsonString
+        The JSON string to repair.
+    
+    .EXAMPLE
+        $fixed = Repair-JsonResponse -JsonString '{"text": "keyboard\shortcuts"}'
+        # Returns: '{"text": "keyboard\\shortcuts"}'
+    
+    .NOTES
+        This function should be called before ConvertFrom-Json to prevent
+        "Bad JSON escape sequence" errors.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [AllowEmptyString()]
+        [string]$JsonString
+    )
+
+    if ([string]::IsNullOrEmpty($JsonString)) {
+        return $JsonString
+    }
+
+    # Valid JSON escape characters (after the backslash)
+    # " \ / b f n r t u (for unicode \uXXXX)
+    # Everything else is invalid and needs the backslash escaped
+    
+    # Strategy: Find all backslash sequences and escape invalid ones
+    # We need to be careful not to double-escape already valid sequences
+    
+    # Use a regex to find backslash followed by any character that's NOT a valid escape
+    # Valid escapes: " \ / b f n r t u
+    # Invalid: anything else (s, d, w, a, e, c, g, h, i, j, k, l, m, o, p, q, v, x, y, z, etc.)
+    
+    $result = [System.Text.StringBuilder]::new($JsonString.Length * 2)
+    $i = 0
+    
+    while ($i -lt $JsonString.Length) {
+        $char = $JsonString[$i]
+        
+        if ($char -eq '\' -and ($i + 1) -lt $JsonString.Length) {
+            $nextChar = $JsonString[$i + 1]
+            
+            # Check if the next character is a valid JSON escape character
+            switch ($nextChar) {
+                '"' { 
+                    # Valid: \"
+                    $null = $result.Append('\')
+                    $null = $result.Append('"')
+                    $i += 2
+                }
+                '\' { 
+                    # Valid: \\
+                    $null = $result.Append('\\')
+                    $i += 2
+                }
+                '/' { 
+                    # Valid: \/
+                    $null = $result.Append('\/')
+                    $i += 2
+                }
+                'b' { 
+                    # Valid: \b (backspace)
+                    $null = $result.Append('\b')
+                    $i += 2
+                }
+                'f' { 
+                    # Valid: \f (form feed)
+                    $null = $result.Append('\f')
+                    $i += 2
+                }
+                'n' { 
+                    # Valid: \n (newline)
+                    $null = $result.Append('\n')
+                    $i += 2
+                }
+                'r' { 
+                    # Valid: \r (carriage return)
+                    $null = $result.Append('\r')
+                    $i += 2
+                }
+                't' { 
+                    # Valid: \t (tab)
+                    $null = $result.Append('\t')
+                    $i += 2
+                }
+                'u' { 
+                    # Valid: \uXXXX (unicode) - need to check for 4 hex digits
+                    if (($i + 5) -lt $JsonString.Length) {
+                        $hex = $JsonString.Substring($i + 2, 4)
+                        if ($hex -match '^[0-9a-fA-F]{4}$') {
+                            # Valid unicode escape
+                            $null = $result.Append('\u')
+                            $null = $result.Append($hex)
+                            $i += 6
+                        }
+                        else {
+                            # Invalid: \u not followed by 4 hex digits - escape the backslash
+                            $null = $result.Append('\\')
+                            $null = $result.Append('u')
+                            $i += 2
+                        }
+                    }
+                    else {
+                        # Not enough characters for \uXXXX - escape the backslash
+                        $null = $result.Append('\\')
+                        $null = $result.Append('u')
+                        $i += 2
+                    }
+                }
+                default {
+                    # Invalid escape sequence - escape the backslash to make it valid
+                    # \s becomes \\s, \d becomes \\d, etc.
+                    $null = $result.Append('\\')
+                    $null = $result.Append($nextChar)
+                    $i += 2
+                }
+            }
+        }
+        else {
+            # Regular character, just append
+            $null = $result.Append($char)
+            $i++
+        }
+    }
+    
+    return $result.ToString()
+}

--- a/spec/powershell/Repair-JsonResponse.Tests.ps1
+++ b/spec/powershell/Repair-JsonResponse.Tests.ps1
@@ -1,0 +1,130 @@
+# Repair-JsonResponse.Tests.ps1
+# Tests for JSON response sanitization to handle AI model escape sequence issues
+
+Describe "JSON Escape Sequence Issue Reproduction" {
+    BeforeAll {
+        . "$PSScriptRoot/Initialize-BeforeAll.ps1"
+    }
+
+    BeforeEach {
+        . "$PSScriptRoot/Initialize-BeforeEach.ps1"
+    }
+
+    Context "Reproducing the \s escape sequence error from workflow" {
+        It "Should fail with the exact error when AI returns invalid \s escape sequence" {
+            # This simulates what the AI model returned in the failing workflow
+            # The AI wrote "keyboard\shortcuts" where \s is not a valid JSON escape
+            # 
+            # From the error log:
+            # "Bad JSON escape sequence: \s. Path 'summary', line 4, position 472"
+            #
+            # Valid JSON escape sequences are: \" \\ \/ \b \f \n \r \t \uXXXX
+            # The AI model incorrectly used \s (probably thinking it's regex whitespace)
+            
+            $aiResponseWithBadEscape = @'
+{
+  "skip_article": false,
+  "section": "GitHub Copilot",
+  "summary": "This practical guide focuses on actionable strategies and shortcuts for developers leveraging GitHub Copilot within Visual Studio Code.",
+  "relevance_score": 85
+}
+'@
+            # Inject the bad escape sequence that the AI generated
+            # The AI wrote something like "keyboard\shortcuts" 
+            $aiResponseWithBadEscape = $aiResponseWithBadEscape.Replace("shortcuts", "\shortcuts")
+
+            # This demonstrates the EXACT error from the production workflow
+            { $aiResponseWithBadEscape | ConvertFrom-Json } | Should -Throw "*Bad JSON escape sequence*"
+        }
+
+        It "Should fail with \d escape sequence (AI thinking regex digit)" {
+            $jsonWithInvalidEscape = '{"text": "Match digits with \d pattern"}'
+            { $jsonWithInvalidEscape | ConvertFrom-Json } | Should -Throw
+        }
+
+        It "Should fail with \w escape sequence (AI thinking regex word)" {
+            $jsonWithInvalidEscape = '{"text": "Match words with \w pattern"}'
+            { $jsonWithInvalidEscape | ConvertFrom-Json } | Should -Throw
+        }
+    }
+
+    Context "Valid JSON escape sequences should still work" {
+        It "Should correctly parse JSON with all valid escape sequences" {
+            # These are the ONLY valid JSON escape sequences:
+            # \" \\ \/ \b \f \n \r \t \uXXXX
+            $validJson = @'
+{
+  "newline": "Line 1\nLine 2",
+  "tab": "Col1\tCol2",
+  "quote": "He said \"Hello\"",
+  "backslash": "C:\\Users\\Name",
+  "carriage_return": "Line1\rLine2",
+  "unicode": "\u0041\u0042\u0043"
+}
+'@
+            $result = $validJson | ConvertFrom-Json
+            
+            $result.newline | Should -Be "Line 1`nLine 2"
+            $result.tab | Should -Be "Col1`tCol2"
+            $result.quote | Should -Be 'He said "Hello"'
+            $result.backslash | Should -Be "C:\Users\Name"
+            $result.unicode | Should -Be "ABC"
+        }
+    }
+
+    Context "Repair-JsonResponse function should fix invalid escapes" {
+        It "Should have a Repair-JsonResponse function available" {
+            # The iterative-roundup-generation.ps1 script needs this function
+            # to sanitize AI responses before parsing with ConvertFrom-Json
+            $functionExists = Get-Command -Name "Repair-JsonResponse" -ErrorAction SilentlyContinue
+            
+            $functionExists | Should -Not -BeNullOrEmpty -Because "AI models generate invalid JSON escape sequences that must be sanitized before parsing"
+        }
+
+        It "Should fix \s escape sequences" {
+            $functionExists = Get-Command -Name "Repair-JsonResponse" -ErrorAction SilentlyContinue
+            if (-not $functionExists) {
+                Set-ItResult -Skipped -Because "Repair-JsonResponse function not yet implemented"
+                return
+            }
+
+            $brokenJson = '{"summary": "keyboard\shortcuts for developers"}'
+            $fixedJson = Repair-JsonResponse -JsonString $brokenJson
+            
+            { $fixedJson | ConvertFrom-Json } | Should -Not -Throw
+        }
+
+        It "Should fix \d, \w, \a, \e and other invalid single-letter escapes" {
+            $functionExists = Get-Command -Name "Repair-JsonResponse" -ErrorAction SilentlyContinue
+            if (-not $functionExists) {
+                Set-ItResult -Skipped -Because "Repair-JsonResponse function not yet implemented"
+                return
+            }
+
+            $brokenJson = '{"text": "regex \d digits \w words \a alert \e escape"}'
+            $fixedJson = Repair-JsonResponse -JsonString $brokenJson
+            
+            { $fixedJson | ConvertFrom-Json } | Should -Not -Throw
+        }
+
+        It "Should preserve valid escape sequences while fixing invalid ones" {
+            $functionExists = Get-Command -Name "Repair-JsonResponse" -ErrorAction SilentlyContinue
+            if (-not $functionExists) {
+                Set-ItResult -Skipped -Because "Repair-JsonResponse function not yet implemented"
+                return
+            }
+
+            # Mix of valid (\n, \\) and invalid (\s) escapes
+            $mixedJson = '{"path": "C:\\Users\\Name", "broken": "keyboard\shortcuts", "newline": "line1\nline2"}'
+            
+            $fixedJson = Repair-JsonResponse -JsonString $mixedJson
+            $result = $fixedJson | ConvertFrom-Json
+            
+            # Valid escapes must be preserved exactly
+            $result.path | Should -Be "C:\Users\Name"
+            $result.newline | Should -Be "line1`nline2"
+            # Invalid escape should be fixed (backslash escaped to \\)
+            $result.broken | Should -Match "shortcuts"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the weekly roundup workflow failure caused by invalid JSON escape sequences in AI responses.

## Problem

AI models (GPT-4.1) sometimes return JSON with invalid escape sequences like `\s`, `\d`, `\w` (regex patterns) which are not valid per the JSON specification. This causes `ConvertFrom-Json` to fail with:

```
Bad JSON escape sequence: \s. Path 'summary', line 4, position 472
```

## Solution

- **New function**: `Repair-JsonResponse.ps1` - Sanitizes AI responses by converting invalid escape sequences to valid ones (`\s` → `\\s`)
- **Integration**: Added sanitization in `Invoke-AiApiCall.ps1` before returning AI content
- **Benefit**: All callers automatically benefit from the fix without code changes

## Technical Details

JSON only supports these escape sequences: `\" \\ \/ \b \f \n \r \t \uXXXX`

The fix parses the JSON string character-by-character, preserving valid escapes while converting invalid ones to escaped backslashes.

## Testing

- ✅ 8 new tests in `Repair-JsonResponse.Tests.ps1`
- ✅ All 21 existing `Invoke-AiApiCall.Tests.ps1` tests pass
- ✅ All 425 PowerShell tests pass

## Files Changed

| File | Change |
|------|--------|
| `.github/scripts/functions/Repair-JsonResponse.ps1` | New - JSON sanitization function |
| `.github/scripts/functions/Invoke-AiApiCall.ps1` | Modified - Added sanitization call |
| `spec/powershell/Repair-JsonResponse.Tests.ps1` | New - Unit tests |