### PR TITLE
Fix HTTP error response body not being logged in AI API calls

### DIFF
--- a/scripts/content-processing/functions/Get-WebResponseDetailsFromException.ps1
+++ b/scripts/content-processing/functions/Get-WebResponseDetailsFromException.ps1
@@ -2,7 +2,10 @@ function Get-WebResponseDetailsFromException {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
-        $Exception
+        $Exception,
+
+        [Parameter(Mandatory = $false)]
+        $ErrorRecord
     )
 
     $statusCode = $null
@@ -90,6 +93,22 @@ function Get-WebResponseDetailsFromException {
         }
         catch {
             Write-ErrorDetails -ErrorRecord $_ -Context "Failed to get response content from web response"
+        }
+
+        # Fallback: In PowerShell 7, Invoke-WebRequest stores the HTTP response body in
+        # ErrorRecord.ErrorDetails.Message. Use it when no useful content was extracted
+        # (e.g. when Content.ToString() returns just the .NET type name).
+        if ($ErrorRecord -and $ErrorRecord.PSObject.Properties.Name -contains "ErrorDetails" -and
+            $ErrorRecord.ErrorDetails -and $ErrorRecord.ErrorDetails.PSObject.Properties.Name -contains "Message" -and
+            $ErrorRecord.ErrorDetails.Message) {
+            if (-not $responseContent -or $responseContent -match '^System\.') {
+                $responseContent = $ErrorRecord.ErrorDetails.Message
+            }
+        }
+
+        # Clear responseContent if it's just a .NET type name (not useful)
+        if ($responseContent -match '^System\.') {
+            $responseContent = $null
         }
     }
     catch {

--- a/scripts/content-processing/functions/Invoke-AiApiCall.ps1
+++ b/scripts/content-processing/functions/Invoke-AiApiCall.ps1
@@ -91,7 +91,7 @@ function Invoke-AiApiCall {
                 Write-ErrorDetails -ErrorRecord $_ -Context "AI API call, waiting $RateLimitPreventionDelay seconds before processing failure..."
                 Start-Sleep -Seconds $RateLimitPreventionDelay
 
-                $webResponseDetails = Get-WebResponseDetailsFromException -Exception $_.Exception
+                $webResponseDetails = Get-WebResponseDetailsFromException -Exception $_.Exception -ErrorRecord $_
                 $statusCode = $webResponseDetails.StatusCode
                 $statusDescription = $webResponseDetails.StatusDescription
                 $responseHeaders = $webResponseDetails.Headers

--- a/tests/powershell/Get-WebResponseDetailsFromException.Tests.ps1
+++ b/tests/powershell/Get-WebResponseDetailsFromException.Tests.ps1
@@ -188,4 +188,117 @@ Describe "Get-WebResponseDetailsFromException" {
             $result.ResponseContent | Should -BeNullOrEmpty
         }
     }
+
+    Context "ErrorRecord Fallback for Response Content" {
+        It "Should extract response content from ErrorRecord.ErrorDetails.Message when content extraction fails" {
+            # Arrange - Simulates PowerShell 7 Invoke-WebRequest failure where
+            # the response body is available via ErrorRecord.ErrorDetails.Message
+            # but NOT via the exception's Response.Content (stream already consumed)
+            $mockResponse = [PSCustomObject]@{
+                StatusCode = 400
+                StatusDescription = "Bad Request"
+                Headers = @{}
+                Content = "System.Net.Http.HttpConnectionResponseContent"
+                PSTypeName = "System.Net.Http.HttpResponseMessage"
+            }
+
+            $mockException = [PSCustomObject]@{
+                Response = $mockResponse
+                Message = "Response status code does not indicate success: 400 (Bad Request)."
+                PSTypeName = "Microsoft.PowerShell.Commands.HttpResponseException"
+            }
+
+            $mockErrorDetails = [PSCustomObject]@{
+                Message = '{"error":{"message":"The request was invalid.","type":"invalid_request_error","code":"invalid_request"}}'
+            }
+
+            $mockErrorRecord = [PSCustomObject]@{
+                Exception = $mockException
+                ErrorDetails = $mockErrorDetails
+            }
+
+            # Act
+            $result = Get-WebResponseDetailsFromException -Exception $mockException -ErrorRecord $mockErrorRecord
+
+            # Assert
+            $result.StatusCode | Should -Be 400
+            $result.ResponseContent | Should -Be '{"error":{"message":"The request was invalid.","type":"invalid_request_error","code":"invalid_request"}}'
+        }
+
+        It "Should not override valid response content with ErrorRecord fallback" {
+            # Arrange - Response.Content has real content, ErrorRecord also has content
+            $mockResponse = [PSCustomObject]@{
+                StatusCode = 400
+                StatusDescription = "Bad Request"
+                Headers = @{}
+                Content = '{"error":"from response content"}'
+                PSTypeName = "System.Net.Http.HttpResponseMessage"
+            }
+
+            $mockException = [PSCustomObject]@{
+                Response = $mockResponse
+                Message = "Response status code does not indicate success: 400 (Bad Request)."
+                PSTypeName = "Microsoft.PowerShell.Commands.HttpResponseException"
+            }
+
+            $mockErrorDetails = [PSCustomObject]@{
+                Message = '{"error":"from error details"}'
+            }
+
+            $mockErrorRecord = [PSCustomObject]@{
+                Exception = $mockException
+                ErrorDetails = $mockErrorDetails
+            }
+
+            # Act
+            $result = Get-WebResponseDetailsFromException -Exception $mockException -ErrorRecord $mockErrorRecord
+
+            # Assert - Should use the content from the response, not the ErrorRecord fallback
+            $result.ResponseContent | Should -Be '{"error":"from response content"}'
+        }
+
+        It "Should work without ErrorRecord parameter (backward compatible)" {
+            # Arrange
+            $mockException = [PSCustomObject]@{
+                Message = "Response status code does not indicate success: 400 (Bad Request)."
+                PSTypeName = "Microsoft.PowerShell.Commands.HttpResponseException"
+            }
+
+            # Act - No ErrorRecord parameter passed
+            $result = Get-WebResponseDetailsFromException -Exception $mockException
+
+            # Assert
+            $result.StatusCode | Should -Be 400
+            $result.StatusDescription | Should -Be "Bad Request"
+            $result.ResponseContent | Should -BeNullOrEmpty
+        }
+
+        It "Should use ErrorRecord fallback when content is a .NET type name string" {
+            # Arrange - This is the exact bug scenario: Content.ToString() returns the type name
+            $mockResponse = [PSCustomObject]@{
+                StatusCode = 400
+                StatusDescription = "Bad Request"
+                Headers = @{}
+                Content = "System.Net.Http.HttpConnectionResponseContent"
+                PSTypeName = "System.Net.Http.HttpResponseMessage"
+            }
+
+            $mockException = [PSCustomObject]@{
+                Response = $mockResponse
+                Message = "Response status code does not indicate success: 400 (Bad Request)."
+                PSTypeName = "Microsoft.PowerShell.Commands.HttpResponseException"
+            }
+
+            $mockErrorRecord = [PSCustomObject]@{
+                Exception = $mockException
+                ErrorDetails = $null
+            }
+
+            # Act - ErrorRecord has no ErrorDetails
+            $result = Get-WebResponseDetailsFromException -Exception $mockException -ErrorRecord $mockErrorRecord
+
+            # Assert - Should detect the type name string is not useful content
+            $result.ResponseContent | Should -BeNullOrEmpty
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The Weekly Roundup Generation workflow failed because HTTP 400 error responses from Azure OpenAI were not being logged properly. Instead of the actual API error body (e.g. content filter violations, invalid request details), the logs showed the .NET type name `System.Net.Http.HttpConnectionResponseContent` — making the errors completely undiagnosable.

This bug occurs because in PowerShell 7, when `Invoke-WebRequest` fails, the response body stream is already consumed by the time `Get-WebResponseDetailsFromException` tries to read it. The `Content.ToString()` fallback just returns the class name.

## Solution

Added a fallback path that reads the HTTP response body from `ErrorRecord.ErrorDetails.Message` — where PowerShell 7 stores it for failed `Invoke-WebRequest` calls. The fix is backward-compatible: the new `ErrorRecord` parameter is optional.

## Technical Changes

- **`Get-WebResponseDetailsFromException.ps1`**: Added optional `ErrorRecord` parameter. After existing content extraction attempts, falls back to `ErrorRecord.ErrorDetails.Message` when `responseContent` is null or a `.NET` type name string. Also clears useless `System.*` type name strings.
- **`Invoke-AiApiCall.ps1`**: Updated caller to pass `-ErrorRecord $_` alongside `-Exception $_.Exception`.
- **`Get-WebResponseDetailsFromException.Tests.ps1`**: Added 4 Pester tests: ErrorRecord fallback extraction, content precedence (real content not overridden), backward compatibility, and type name detection.

## Testing

All 353 PowerShell tests pass (349 existing + 4 new).
