### PR TITLE
Fix hero banner mobile spacing and button height issues

### DIFF
--- a/src/TechHub.Web/Components/HeroBanner.razor.css
+++ b/src/TechHub.Web/Components/HeroBanner.razor.css
@@ -229,5 +229,10 @@
     .hero-banner-find-more-text {
         display: none;
     }
+
+    /* Keep button the same height as when text was visible */
+    .hero-banner-find-more {
+        min-height: 1.625rem;
+    }
 }
 

--- a/src/TechHub.Web/wwwroot/css/page-container.css
+++ b/src/TechHub.Web/wwwroot/css/page-container.css
@@ -82,7 +82,6 @@ html.sidebar-collapsed .page-with-sidebar {
     --section-grid-columns: 2;
     grid-template-columns: 1fr;
     gap: var(--spacing-3);
-    padding: var(--spacing-3);
     transition: none;
     align-content: start;
   }
@@ -101,6 +100,7 @@ html.sidebar-collapsed .page-with-sidebar {
   .page-with-sidebar > .hero-banner {
     grid-column: 1;
     order: -1;
+    margin-bottom: 0; /* Grid gap handles spacing; desktop margin would double it */
   }
 
   /* Disable collapsed state on mobile */


### PR DESCRIPTION
## Summary

Fix three CSS issues in the hero banner mobile/responsive views:

1. **Double spacing below hero banner** — When the sidebar switches to toolbar mode (≤1292px), the grid gap and the hero banner's margin-bottom both applied ar(--spacing-3), causing double spacing. Removed the margin in mobile view since the grid gap handles it.

2. **Find-more button shrinks when text is hidden** — On small screens (≤700px), the "Find a GitHub Copilot Dev Day near you" text is hidden, leaving only the globe icon. The button height collapsed. Added min-height: 1.625rem to maintain consistent button height.

3. **Duplicate CSS padding** — The .page-with-sidebar base rule already sets padding: var(--spacing-3), so the identical declaration in the max-width: 1292px media query was redundant. Removed it.

## Changes

- `src/TechHub.Web/wwwroot/css/page-container.css` — Remove duplicate padding, add `margin-bottom: 0` for mobile hero banner
- `src/TechHub.Web/Components/HeroBanner.razor.css` — Add `min-height` to find-more button in mobile breakpoint
