### PR TITLE
Fix post-deployment content processing bugs and add admin date editing

### DIFF
--- a/src/TechHub.Api/Endpoints/AdminEndpoints.cs
+++ b/src/TechHub.Api/Endpoints/AdminEndpoints.cs
@@ -592,6 +592,11 @@ public static class AdminEndpoints
             return Results.BadRequest("At least one section is required.");
         }
 
+        if (request.DateEpoch <= 0)
+        {
+            return Results.BadRequest("A valid date is required.");
+        }
+
         // Validate ai_metadata JSON if provided
         if (!string.IsNullOrWhiteSpace(request.AiMetadata))
         {

--- a/src/TechHub.Core/Models/Admin/ContentItemEditData.cs
+++ b/src/TechHub.Core/Models/Admin/ContentItemEditData.cs
@@ -8,6 +8,10 @@ public sealed record ContentItemEditData
 {
     public required string CollectionName { get; init; }
     public required string Slug { get; init; }
+
+    /// <summary>Unix epoch publication date (seconds). Editable in admin UI.</summary>
+    public long DateEpoch { get; init; }
+
     public required string Title { get; init; }
     public required string Author { get; init; }
     public required string Excerpt { get; init; }

--- a/src/TechHub.Core/Models/ContentProcessing/ProcessedContentItem.cs
+++ b/src/TechHub.Core/Models/ContentProcessing/ProcessedContentItem.cs
@@ -107,6 +107,32 @@ public sealed class ProcessedContentItem
     }
 
     /// <summary>
+    /// Creates a copy of this item with the specified date epoch.
+    /// Used to cap future-dated items to the processing date.
+    /// </summary>
+    public ProcessedContentItem WithDateEpoch(long dateEpoch)
+    {
+        return new ProcessedContentItem
+        {
+            Slug = Slug,
+            Title = Title,
+            Content = Content,
+            Excerpt = Excerpt,
+            DateEpoch = dateEpoch,
+            CollectionName = CollectionName,
+            SubcollectionName = SubcollectionName,
+            ExternalUrl = ExternalUrl,
+            Author = Author,
+            FeedName = FeedName,
+            Tags = Tags,
+            Sections = Sections,
+            PrimarySectionName = PrimarySectionName,
+            ContentHash = ContentHash,
+            RoundupMetadata = RoundupMetadata
+        };
+    }
+
+    /// <summary>
     /// Creates a copy of this item with the specified tags.
     /// </summary>
     public ProcessedContentItem WithTags(IReadOnlyList<string> tags)

--- a/src/TechHub.Infrastructure/Repositories/ContentRepository.cs
+++ b/src/TechHub.Infrastructure/Repositories/ContentRepository.cs
@@ -1615,17 +1615,42 @@ WHERE collection_name = @CollectionName AND slug = @Slug";
             Slug = slug
         };
 
-        var rows = await Connection.ExecuteAsync(
-            new CommandDefinition(ItemSql, parameters, cancellationToken: ct));
-
-        if (rows > 0)
+        var rows = 0;
+        using var transaction = Connection.BeginTransaction();
+        try
         {
-            // Sync denormalized date_epoch in content_tags_expanded
-            await Connection.ExecuteAsync(
-                new CommandDefinition(
-                    "UPDATE content_tags_expanded SET date_epoch = @DateEpoch WHERE collection_name = @CollectionName AND slug = @Slug",
-                    new { editData.DateEpoch, CollectionName = collectionName, Slug = slug },
-                    cancellationToken: ct));
+            rows = await Connection.ExecuteAsync(
+                new CommandDefinition(ItemSql, parameters, transaction: transaction, cancellationToken: ct));
+
+            if (rows > 0)
+            {
+                // Sync all denormalized fields in content_tags_expanded atomically.
+                // Admin edits can change date_epoch, section booleans, and sections_bitmask —
+                // all are denormalized here and must stay in sync with content_items.
+                await Connection.ExecuteAsync(
+                    new CommandDefinition(
+                        @"UPDATE content_tags_expanded
+                          SET date_epoch        = @DateEpoch,
+                              is_ai             = @IsAi,
+                              is_azure          = @IsAzure,
+                              is_dotnet         = @IsDotnet,
+                              is_devops         = @IsDevops,
+                              is_github_copilot = @IsGhc,
+                              is_ml             = @IsMl,
+                              is_security       = @IsSecurity,
+                              sections_bitmask  = @Bitmask
+                          WHERE collection_name = @CollectionName AND slug = @Slug",
+                        parameters,
+                        transaction: transaction,
+                        cancellationToken: ct));
+            }
+
+            transaction.Commit();
+        }
+        catch
+        {
+            transaction.Rollback();
+            throw;
         }
 
         return rows > 0;

--- a/src/TechHub.Infrastructure/Repositories/ContentRepository.cs
+++ b/src/TechHub.Infrastructure/Repositories/ContentRepository.cs
@@ -1615,11 +1615,10 @@ WHERE collection_name = @CollectionName AND slug = @Slug";
             Slug = slug
         };
 
-        var rows = 0;
         using var transaction = Connection.BeginTransaction();
         try
         {
-            rows = await Connection.ExecuteAsync(
+            var rows = await Connection.ExecuteAsync(
                 new CommandDefinition(ItemSql, parameters, transaction: transaction, cancellationToken: ct));
 
             if (rows > 0)
@@ -1646,14 +1645,13 @@ WHERE collection_name = @CollectionName AND slug = @Slug";
             }
 
             transaction.Commit();
+            return rows > 0;
         }
         catch
         {
             transaction.Rollback();
             throw;
         }
-
-        return rows > 0;
     }
 
     // ==================== Admin Content Items ====================

--- a/src/TechHub.Infrastructure/Repositories/ContentRepository.cs
+++ b/src/TechHub.Infrastructure/Repositories/ContentRepository.cs
@@ -1478,7 +1478,7 @@ WHERE collection_name = @CollectionName AND slug = @Slug";
         CancellationToken ct = default)
     {
         const string Sql = @"
-SELECT collection_name, slug, title, author, excerpt, content, primary_section_name,
+SELECT collection_name, slug, date_epoch, title, author, excerpt, content, primary_section_name,
        tags_csv, ai_metadata::text AS ai_metadata,
        is_ai, is_azure, is_dotnet, is_devops, is_github_copilot, is_ml, is_security
 FROM content_items
@@ -1538,6 +1538,7 @@ LIMIT 1";
         {
             CollectionName = (string)row.collection_name,
             Slug = (string)row.slug,
+            DateEpoch = (long)row.date_epoch,
             Title = (string)row.title,
             Author = (string)row.author,
             Excerpt = (string)row.excerpt,
@@ -1571,12 +1572,13 @@ LIMIT 1";
         var isSecurity = editData.Sections.Contains("security");
         var bitmask = CalculateSectionBitmask(editData.Sections);
 
-        const string Sql = @"
+        const string ItemSql = @"
 UPDATE content_items
 SET title                = @Title,
     author               = @Author,
     excerpt              = @Excerpt,
     content              = @Content,
+    date_epoch           = @DateEpoch,
     primary_section_name = @PrimarySectionName,
     tags_csv             = @TagsCsv,
     is_ai                = @IsAi,
@@ -1591,27 +1593,41 @@ SET title                = @Title,
     updated_at           = NOW()
 WHERE collection_name = @CollectionName AND slug = @Slug";
 
+        var parameters = new
+        {
+            Title = editData.Title,
+            Author = editData.Author,
+            Excerpt = editData.Excerpt,
+            Content = editData.Content,
+            DateEpoch = editData.DateEpoch,
+            PrimarySectionName = editData.PrimarySectionName,
+            TagsCsv = tagsCsv,
+            IsAi = isAi,
+            IsAzure = isAzure,
+            IsDotnet = isDotnet,
+            IsDevops = isDevops,
+            IsGhc = isGhc,
+            IsMl = isMl,
+            IsSecurity = isSecurity,
+            Bitmask = bitmask,
+            AiMetadata = editData.AiMetadata,
+            CollectionName = collectionName,
+            Slug = slug
+        };
+
         var rows = await Connection.ExecuteAsync(
-            new CommandDefinition(Sql, new
-            {
-                Title = editData.Title,
-                Author = editData.Author,
-                Excerpt = editData.Excerpt,
-                Content = editData.Content,
-                PrimarySectionName = editData.PrimarySectionName,
-                TagsCsv = tagsCsv,
-                IsAi = isAi,
-                IsAzure = isAzure,
-                IsDotnet = isDotnet,
-                IsDevops = isDevops,
-                IsGhc = isGhc,
-                IsMl = isMl,
-                IsSecurity = isSecurity,
-                Bitmask = bitmask,
-                AiMetadata = editData.AiMetadata,
-                CollectionName = collectionName,
-                Slug = slug
-            }, cancellationToken: ct));
+            new CommandDefinition(ItemSql, parameters, cancellationToken: ct));
+
+        if (rows > 0)
+        {
+            // Sync denormalized date_epoch in content_tags_expanded
+            await Connection.ExecuteAsync(
+                new CommandDefinition(
+                    "UPDATE content_tags_expanded SET date_epoch = @DateEpoch WHERE collection_name = @CollectionName AND slug = @Slug",
+                    new { editData.DateEpoch, CollectionName = collectionName, Slug = slug },
+                    cancellationToken: ct));
+        }
+
         return rows > 0;
     }
 

--- a/src/TechHub.Infrastructure/Services/ContentProcessing/ContentProcessingService.cs
+++ b/src/TechHub.Infrastructure/Services/ContentProcessing/ContentProcessingService.cs
@@ -269,6 +269,8 @@ public sealed class ContentProcessingService
                             else
                             {
                                 transcriptsFailed++;
+                                Log(string.Create(CultureInfo.InvariantCulture,
+                                    $"  ⚠ Transcript unavailable: {raw.ExternalUrl} — {raw.TranscriptFailureReason ?? "unknown"}"));
 
                                 // Enforce TranscriptMandatory — fail the item if transcript is required but absent
                                 if (feed.TranscriptMandatory)
@@ -343,6 +345,18 @@ public sealed class ContentProcessingService
                         }
 
                         var processed = categorizationResult.Item;
+
+                        // Cap future-dated items to the processing date.
+                        // Some feeds publish articles with dates a few days in the future.
+                        // Without this cap, the item would be excluded from weekly roundups
+                        // which filter by date range relative to the run time.
+                        var nowEpoch = _timeProvider.GetUtcNow().ToUnixTimeSeconds();
+                        if (processed.DateEpoch > nowEpoch)
+                        {
+                            Log(string.Create(CultureInfo.InvariantCulture,
+                                $"  → Future date capped to now: {raw.ExternalUrl} (was {DateTimeOffset.FromUnixTimeSeconds(processed.DateEpoch):yyyy-MM-dd})"));
+                            processed = processed.WithDateEpoch(nowEpoch);
+                        }
 
                         // Apply subcollection rules from configuration
                         var matchedSubcollection = MatchSubcollectionRule(raw.FeedName, raw.Title);

--- a/src/TechHub.Infrastructure/Services/ContentProcessing/ContentProcessingService.cs
+++ b/src/TechHub.Infrastructure/Services/ContentProcessing/ContentProcessingService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TechHub.Core.Configuration;
 using TechHub.Core.Interfaces;
+using TechHub.Core.Logging;
 using TechHub.Core.Models.ContentProcessing;
 
 namespace TechHub.Infrastructure.Services.ContentProcessing;
@@ -270,7 +271,7 @@ public sealed class ContentProcessingService
                             {
                                 transcriptsFailed++;
                                 Log(string.Create(CultureInfo.InvariantCulture,
-                                    $"  ⚠ Transcript unavailable: {raw.ExternalUrl} — {raw.TranscriptFailureReason ?? "unknown"}"));
+                                    $"  ⚠ Transcript unavailable: {raw.ExternalUrl.Sanitize()} — {(raw.TranscriptFailureReason ?? "unknown").Sanitize()}"));
 
                                 // Enforce TranscriptMandatory — fail the item if transcript is required but absent
                                 if (feed.TranscriptMandatory)
@@ -354,7 +355,7 @@ public sealed class ContentProcessingService
                         if (processed.DateEpoch > nowEpoch)
                         {
                             Log(string.Create(CultureInfo.InvariantCulture,
-                                $"  → Future date capped to now: {raw.ExternalUrl} (was {DateTimeOffset.FromUnixTimeSeconds(processed.DateEpoch):yyyy-MM-dd})"));
+                                $"  → Future date capped to now: {raw.ExternalUrl.Sanitize()} (was {DateTimeOffset.FromUnixTimeSeconds(processed.DateEpoch):yyyy-MM-dd})"));
                             processed = processed.WithDateEpoch(nowEpoch);
                         }
 

--- a/src/TechHub.Infrastructure/Services/ContentProcessing/ContentProcessingService.cs
+++ b/src/TechHub.Infrastructure/Services/ContentProcessing/ContentProcessingService.cs
@@ -276,7 +276,7 @@ public sealed class ContentProcessingService
                                 // Enforce TranscriptMandatory — fail the item if transcript is required but absent
                                 if (feed.TranscriptMandatory)
                                 {
-                                    Log(string.Create(CultureInfo.InvariantCulture, $"  ✗ Failed: {raw.ExternalUrl} — transcript mandatory but not available"));
+                                    Log(string.Create(CultureInfo.InvariantCulture, $"  ✗ Failed: {raw.ExternalUrl.Sanitize()} — transcript mandatory but not available"));
                                     await _processedUrlRepo.RecordFailureAsync(raw.ExternalUrl, "Transcript mandatory but not available", raw.FeedName, raw.CollectionName, reason: null, hasTranscript: false, jobId: jobId, ct: ct);
                                     errorCount++;
                                     await FlushProgressAsync();

--- a/src/TechHub.Infrastructure/Services/ContentProcessing/YouTubeTranscriptService.cs
+++ b/src/TechHub.Infrastructure/Services/ContentProcessing/YouTubeTranscriptService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TechHub.Core.Configuration;
 using TechHub.Core.Interfaces;
+using TechHub.Core.Logging;
 using TechHub.Core.Models.ContentProcessing;
 using YoutubeExplode;
 using YoutubeExplode.Exceptions;
@@ -113,13 +114,13 @@ public class YouTubeTranscriptService : IYouTubeTranscriptService, IDisposable
             catch (VideoUnavailableException ex)
             {
                 // Non-transient: video is private, removed, or region-restricted. No point retrying.
-                _logger.LogWarning("Video unavailable for transcript: {Url} — {Message}", videoUrl, ex.Message);
+                _logger.LogWarning("Video unavailable for transcript: {Url} — {Message}", videoUrl.Sanitize(), ex.Message.Sanitize());
                 return TranscriptResult.Failure(ex.Message);
             }
             catch (VideoUnplayableException ex)
             {
                 // Non-transient: video requires purchase or is age-restricted. No point retrying.
-                _logger.LogWarning("Video unplayable for transcript: {Url} — {Message}", videoUrl, ex.Message);
+                _logger.LogWarning("Video unplayable for transcript: {Url} — {Message}", videoUrl.Sanitize(), ex.Message.Sanitize());
                 return TranscriptResult.Failure(ex.Message);
             }
             catch (Exception ex) when (ex is OperationCanceledException or HttpRequestException or IOException or YoutubeExplodeException)

--- a/src/TechHub.Infrastructure/Services/ContentProcessing/YouTubeTranscriptService.cs
+++ b/src/TechHub.Infrastructure/Services/ContentProcessing/YouTubeTranscriptService.cs
@@ -110,6 +110,18 @@ public class YouTubeTranscriptService : IYouTubeTranscriptService, IDisposable
             {
                 throw;
             }
+            catch (VideoUnavailableException ex)
+            {
+                // Non-transient: video is private, removed, or region-restricted. No point retrying.
+                _logger.LogWarning("Video unavailable for transcript: {Url} — {Message}", videoUrl, ex.Message);
+                return TranscriptResult.Failure(ex.Message);
+            }
+            catch (VideoUnplayableException ex)
+            {
+                // Non-transient: video requires purchase or is age-restricted. No point retrying.
+                _logger.LogWarning("Video unplayable for transcript: {Url} — {Message}", videoUrl, ex.Message);
+                return TranscriptResult.Failure(ex.Message);
+            }
             catch (Exception ex) when (ex is OperationCanceledException or HttpRequestException or IOException or YoutubeExplodeException)
             {
                 if (attempt <= MaxRetryAttempts)

--- a/src/TechHub.Web/Components/ContentItemEditorModal.razor
+++ b/src/TechHub.Web/Components/ContentItemEditorModal.razor
@@ -29,6 +29,11 @@
                     </div>
 
                     <div class="admin-form-group">
+                        <label class="admin-label" for="ci-date">Date</label>
+                        <input id="ci-date" type="date" class="admin-input" @bind="_date" />
+                    </div>
+
+                    <div class="admin-form-group">
                         <label class="admin-label" for="ci-primary-section">Primary Section</label>
                         <select id="ci-primary-section" class="admin-input" @bind="_primarySectionName">
                             <option value="">— select —</option>
@@ -106,6 +111,7 @@
     private ContentItemEditData? _editData;
     private string _title = string.Empty;
     private string _author = string.Empty;
+    private DateOnly? _date;
     private string _excerpt = string.Empty;
     private string _content = string.Empty;
     private string _primarySectionName = string.Empty;
@@ -122,6 +128,9 @@
             _editData = EditData;
             _title = EditData.Title;
             _author = EditData.Author;
+            _date = EditData.DateEpoch > 0
+                ? DateOnly.FromDateTime(DateTimeOffset.FromUnixTimeSeconds(EditData.DateEpoch).UtcDateTime)
+                : null;
             _excerpt = EditData.Excerpt;
             _content = EditData.Content;
             _primarySectionName = EditData.PrimarySectionName;
@@ -213,6 +222,9 @@
         {
             CollectionName = _editData!.CollectionName,
             Slug = _editData.Slug,
+            DateEpoch = _date.HasValue
+                ? new DateTimeOffset(_date.Value.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero).ToUnixTimeSeconds()
+                : _editData.DateEpoch,
             Title = _title.Trim(),
             Author = _author.Trim(),
             Excerpt = _excerpt.Trim(),

--- a/src/TechHub.Web/Components/ContentItemEditorModal.razor
+++ b/src/TechHub.Web/Components/ContentItemEditorModal.razor
@@ -101,6 +101,7 @@
 
 @code {
     private static readonly string[] AllSections = ["ai", "azure", "devops", "dotnet", "github-copilot", "ml", "security"];
+    private static readonly TimeZoneInfo BrusselsTz = TimeZoneInfo.FindSystemTimeZoneById("Europe/Brussels");
 
     [Parameter, EditorRequired] public string Title { get; set; } = string.Empty;
     [Parameter] public ContentItemEditData? EditData { get; set; }
@@ -129,7 +130,7 @@
             _title = EditData.Title;
             _author = EditData.Author;
             _date = EditData.DateEpoch > 0
-                ? DateOnly.FromDateTime(DateTimeOffset.FromUnixTimeSeconds(EditData.DateEpoch).UtcDateTime)
+                ? DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeSeconds(EditData.DateEpoch), BrusselsTz).DateTime)
                 : null;
             _excerpt = EditData.Excerpt;
             _content = EditData.Content;
@@ -223,7 +224,7 @@
             CollectionName = _editData!.CollectionName,
             Slug = _editData.Slug,
             DateEpoch = _date.HasValue
-                ? new DateTimeOffset(_date.Value.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero).ToUnixTimeSeconds()
+                ? new DateTimeOffset(_date.Value.ToDateTime(TimeOnly.MinValue), BrusselsTz.GetUtcOffset(_date.Value.ToDateTime(TimeOnly.MinValue))).ToUnixTimeSeconds()
                 : _editData.DateEpoch,
             Title = _title.Trim(),
             Author = _author.Trim(),

--- a/src/TechHub.Web/Components/Pages/Admin/AdminStatistics.razor
+++ b/src/TechHub.Web/Components/Pages/Admin/AdminStatistics.razor
@@ -56,9 +56,9 @@
                 <div class="admin-stat-value">@_stats.Processing.TranscriptsSucceeded.ToString("N0")</div>
                 <div class="admin-stat-label">Transcripts ✓</div>
             </div>
-            <div class="admin-stat-card">
+            <div class="admin-stat-card" title="All-time count of processed YouTube video URLs where the transcript fetch failed. Includes videos that were later AI-excluded or failed other steps, so this number may exceed the videos collection count.">
                 <div class="admin-stat-value">@_stats.Processing.TranscriptsFailed.ToString("N0")</div>
-                <div class="admin-stat-label">Transcripts ✗</div>
+                <div class="admin-stat-label">Transcript Failures</div>
             </div>
             <div class="admin-stat-card">
                 <div class="admin-stat-value">@_stats.DatabaseSize.TotalSize</div>

--- a/src/TechHub.Web/Services/DateHelper.cs
+++ b/src/TechHub.Web/Services/DateHelper.cs
@@ -19,6 +19,27 @@ public static class DateHelper
         var todayBrussels = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, _brusselsTimeZone).Date;
         var daysDiff = (todayBrussels - brusselsDate).Days;
 
+        if (daysDiff < 0)
+        {
+            var futureDays = -daysDiff;
+            if (futureDays == 1)
+            {
+                return "Tomorrow";
+            }
+
+            if (futureDays < 7)
+            {
+                return $"In {futureDays} days";
+            }
+
+            if (futureDays < 30)
+            {
+                return $"In {futureDays / 7} weeks";
+            }
+
+            return dateTime.ToString("MMM d, yyyy", System.Globalization.CultureInfo.InvariantCulture);
+        }
+
         if (daysDiff == 0)
         {
             return "Today";

--- a/src/TechHub.Web/Services/DateHelper.cs
+++ b/src/TechHub.Web/Services/DateHelper.cs
@@ -34,7 +34,8 @@ public static class DateHelper
 
             if (futureDays < 30)
             {
-                return $"In {futureDays / 7} weeks";
+                var weeks = futureDays / 7;
+                return weeks == 1 ? "In 1 week" : $"In {weeks} weeks";
             }
 
             return dateTime.ToString("MMM d, yyyy", System.Globalization.CultureInfo.InvariantCulture);

--- a/tests/TechHub.Api.Tests/Endpoints/AdminEndpointsTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/AdminEndpointsTests.cs
@@ -492,6 +492,7 @@ public class AdminEndpointsTests : IClassFixture<TechHubIntegrationTestApiFactor
         {
             CollectionName = collectionName,
             Slug = slug,
+            DateEpoch = 1700000000L,
             Title = "Updated Title",
             Author = "Test Author",
             Excerpt = "Updated excerpt",

--- a/tests/TechHub.E2E.Tests/Web/TabOrderingTests.cs
+++ b/tests/TechHub.E2E.Tests/Web/TabOrderingTests.cs
@@ -330,6 +330,13 @@ public class TabOrderingTests : PlaywrightTestBase
         // Step 2: Enter to activate skip link
         await Page.Keyboard.PressAsync("Enter");
 
+        // Wait for Blazor to finish any re-rendering triggered by the hash change.
+        // Pressing Enter on <a href="#skiptohere"> can cause Blazor's enhanced
+        // navigation to intercept the hash change and re-render the page, which
+        // replaces DOM elements and loses focus. Waiting for Blazor to be ready
+        // ensures re-rendering is complete before we check/set focus.
+        await Page.WaitForBlazorReadyAsync();
+
         // Wait for focus to move to #skiptohere target (browser navigation to hash)
         await Page.WaitForConditionAsync(
             "() => { const el = document.activeElement; return el && (el.id === 'skiptohere' || el.tagName === 'H1' || el === document.body); }");
@@ -340,6 +347,24 @@ public class TabOrderingTests : PlaywrightTestBase
         );
         var validFocusTargets = new[] { "skiptohere", "h1", "body" };
         validFocusTargets.Should().Contain(focusInfo, "after activating skip link, focus should be on heading or body");
+
+        // CI race: Blazor re-render can move focus from the heading to body. If that happened,
+        // re-focus the heading so Tab reliably lands on the first section card — the same
+        // self-heal used in SkipLink_WhenActivated_ShouldMoveFocus_ToMainContent.
+        await Page.EvaluateAsync(@"() => {
+            const el = document.activeElement;
+            if (!el || (el.id !== 'skiptohere' && el.tagName !== 'H1')) {
+                const heading = document.getElementById('skiptohere');
+                if (heading) {
+                    heading.setAttribute('tabindex', '-1');
+                    heading.focus({ preventScroll: true });
+                    heading.addEventListener('blur', function removeTabIndex() {
+                        heading.removeAttribute('tabindex');
+                        heading.removeEventListener('blur', removeTabIndex);
+                    }, { once: true });
+                }
+            }
+        }");
 
         // Step 3: Tab to first focusable element in primary content (should be first section card)
         await Page.Keyboard.PressAsync("Tab");

--- a/tests/TechHub.Infrastructure.Tests/Services/ContentProcessingServiceTests.cs
+++ b/tests/TechHub.Infrastructure.Tests/Services/ContentProcessingServiceTests.cs
@@ -73,9 +73,16 @@ public class ContentProcessingServiceTests
     }
 
     /// <summary>Minimal stub that returns a fixed point in time.</summary>
-    private sealed class FrozenTimeProvider(DateTimeOffset fixedTime) : TimeProvider
+    private sealed class FrozenTimeProvider : TimeProvider
     {
-        public override DateTimeOffset GetUtcNow() => fixedTime;
+        private readonly DateTimeOffset _fixedTime;
+
+        public FrozenTimeProvider(DateTimeOffset fixedTime)
+        {
+            _fixedTime = fixedTime;
+        }
+
+        public override DateTimeOffset GetUtcNow() => _fixedTime;
     }
 
     private static RawFeedItem CreateRawItem(string url = "https://example.com/article-1", string title = "Test Article") => new()

--- a/tests/TechHub.Infrastructure.Tests/Services/ContentProcessingServiceTests.cs
+++ b/tests/TechHub.Infrastructure.Tests/Services/ContentProcessingServiceTests.cs
@@ -43,7 +43,7 @@ public class ContentProcessingServiceTests
         _writeRepo = new ContentItemWriteRepository(fixture.Connection, NullLogger<ContentItemWriteRepository>.Instance);
     }
 
-    private ContentProcessingService CreateService(ContentProcessorOptions? options = null)
+    private ContentProcessingService CreateService(ContentProcessorOptions? options = null, TimeProvider? timeProvider = null)
     {
         var opts = options ?? new ContentProcessorOptions();
 
@@ -67,9 +67,15 @@ public class ContentProcessingServiceTests
             _processedUrlRepo,
             _feedRepo.Object,
             _contentFixer.Object,
-            TimeProvider.System,
+            timeProvider ?? TimeProvider.System,
             Options.Create(opts),
             NullLogger<ContentProcessingService>.Instance);
+    }
+
+    /// <summary>Minimal stub that returns a fixed point in time.</summary>
+    private sealed class FrozenTimeProvider(DateTimeOffset fixedTime) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => fixedTime;
     }
 
     private static RawFeedItem CreateRawItem(string url = "https://example.com/article-1", string title = "Test Article") => new()
@@ -1192,5 +1198,56 @@ public class ContentProcessingServiceTests
             "SELECT subcollection_name FROM content_items WHERE external_url = @Url",
             new { Url = url });
         ((string?)dbItem!.subcollection_name).Should().BeNull();
+    }
+
+    // ── Future Date Cap ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RunAsync_WhenItemHasFutureDate_CapsDateEpochToNow()
+    {
+        // Arrange
+        var testId = Guid.NewGuid().ToString("N")[..8];
+        var url = $"https://example.com/future-dated-{testId}";
+        var slug = $"future-dated-{testId}";
+        var feed = new FeedConfig { Id = 1, Name = "Test", Url = "https://example.com/feed", OutputDir = "_blogs", Enabled = true };
+        var rawItem = CreateRawItem(url);
+
+        // "Now" is frozen to a fixed point; future date is 5 days ahead
+        var frozenNow = new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero);
+        var futureDateEpoch = frozenNow.AddDays(5).ToUnixTimeSeconds();
+
+        var processed = new ProcessedContentItem
+        {
+            Slug = slug,
+            Title = "Future Article",
+            Excerpt = "An article published in the future",
+            DateEpoch = futureDateEpoch,
+            CollectionName = "blogs",
+            ExternalUrl = url,
+            FeedName = "Test Feed",
+            ContentHash = $"hash-{testId}",
+            Sections = ["ai"],
+            PrimarySectionName = "ai",
+            Tags = []
+        };
+
+        _feedRepo.Setup(r => r.GetEnabledAsync(It.IsAny<CancellationToken>())).ReturnsAsync([feed]);
+        _rssService.Setup(r => r.IngestAsync(feed, It.IsAny<CancellationToken>())).ReturnsAsync(FeedIngestionResult.Success([rawItem]));
+        _aiService.Setup(s => s.CategorizeAsync(It.IsAny<RawFeedItem>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CategorizationResult { Item = processed, Explanation = "Included" });
+
+        var sut = CreateService(timeProvider: new FrozenTimeProvider(frozenNow));
+
+        // Act
+        await sut.RunAsync("scheduled", CancellationToken.None);
+
+        // Assert — date_epoch in DB must not exceed frozenNow
+        var storedEpoch = await _fixture.Connection.QueryFirstOrDefaultAsync<long?>(
+            "SELECT date_epoch FROM content_items WHERE slug = @Slug AND collection_name = @Collection",
+            new { Slug = slug, Collection = "blogs" });
+
+        storedEpoch.Should().NotBeNull("item should have been written to DB");
+        storedEpoch!.Value.Should().Be(frozenNow.ToUnixTimeSeconds(),
+            "future-dated items must be capped to the processing time");
     }
 }

--- a/tests/TechHub.Web.Tests/Services/DateHelperFormatDateRelativeTests.cs
+++ b/tests/TechHub.Web.Tests/Services/DateHelperFormatDateRelativeTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using TechHub.Web.Services;
+
+namespace TechHub.Web.Tests.Services;
+
+/// <summary>
+/// Tests for DateHelper.FormatDateRelative which formats Unix epoch timestamps
+/// as relative date strings using the Europe/Brussels timezone.
+/// </summary>
+public class DateHelperFormatDateRelativeTests
+{
+
+    [Fact]
+    public void FormatDateRelative_Today_ReturnsToday()
+    {
+        // Arrange - exactly the current day in Brussels (we just need "Today" to round-trip,
+        // so use DateTimeOffset.UtcNow which DateHelper also uses for "today")
+        var epoch = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        // Act
+        var result = DateHelper.FormatDateRelative(epoch);
+
+        // Assert
+        result.Should().Be("Today");
+    }
+
+    [Fact]
+    public void FormatDateRelative_Yesterday_ReturnsYesterday()
+    {
+        // Arrange
+        var epoch = DateTimeOffset.UtcNow.AddDays(-1).ToUnixTimeSeconds();
+
+        // Act
+        var result = DateHelper.FormatDateRelative(epoch);
+
+        // Assert
+        result.Should().Be("Yesterday");
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(6)]
+    public void FormatDateRelative_DaysAgo_ReturnsDaysAgoString(int daysAgo)
+    {
+        // Arrange
+        var epoch = DateTimeOffset.UtcNow.AddDays(-daysAgo).ToUnixTimeSeconds();
+
+        // Act
+        var result = DateHelper.FormatDateRelative(epoch);
+
+        // Assert
+        result.Should().Be($"{daysAgo} days ago");
+    }
+
+    [Fact]
+    public void FormatDateRelative_Tomorrow_ReturnsTomorrow()
+    {
+        // Arrange
+        var epoch = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeSeconds();
+
+        // Act
+        var result = DateHelper.FormatDateRelative(epoch);
+
+        // Assert
+        result.Should().Be("Tomorrow");
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(6)]
+    public void FormatDateRelative_FutureDays_ReturnsInXDays(int futureDays)
+    {
+        // Arrange
+        var epoch = DateTimeOffset.UtcNow.AddDays(futureDays).ToUnixTimeSeconds();
+
+        // Act
+        var result = DateHelper.FormatDateRelative(epoch);
+
+        // Assert
+        result.Should().Be($"In {futureDays} days");
+    }
+
+    [Theory]
+    [InlineData(7, "In 1 week")]
+    [InlineData(8, "In 1 week")]
+    [InlineData(13, "In 1 week")]
+    [InlineData(14, "In 2 weeks")]
+    [InlineData(21, "In 3 weeks")]
+    [InlineData(28, "In 4 weeks")]
+    public void FormatDateRelative_FutureWeeks_ReturnsCorrectPluralisation(int futureDays, string expected)
+    {
+        // Arrange
+        var epoch = DateTimeOffset.UtcNow.AddDays(futureDays).ToUnixTimeSeconds();
+
+        // Act
+        var result = DateHelper.FormatDateRelative(epoch);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void FormatDateRelative_FarFuture_ReturnsFormattedDate()
+    {
+        // Arrange — more than 30 days in the future should return a formatted date string
+        var futureDate = new DateTimeOffset(2030, 12, 25, 12, 0, 0, TimeSpan.Zero);
+        var epoch = futureDate.ToUnixTimeSeconds();
+
+        // Act
+        var result = DateHelper.FormatDateRelative(epoch);
+
+        // Assert — formatted as "MMM d, yyyy" (invariant culture)
+        result.Should().Be("Dec 25, 2030");
+    }
+}

--- a/tests/TechHub.Web.Tests/Services/DateHelperFormatDateRelativeTests.cs
+++ b/tests/TechHub.Web.Tests/Services/DateHelperFormatDateRelativeTests.cs
@@ -9,7 +9,6 @@ namespace TechHub.Web.Tests.Services;
 /// </summary>
 public class DateHelperFormatDateRelativeTests
 {
-
     [Fact]
     public void FormatDateRelative_Today_ReturnsToday()
     {


### PR DESCRIPTION
Three production bugs were observed after the first run of the new C# content processing pipeline, plus a date display issue identified shortly after. This PR fixes all three bugs and adds date editing to the admin UI.

## Problems & Solutions

**1. YouTube transcript retries (bug fix)**
VideoUnavailableException and VideoUnplayableException (private/removed/age-restricted/purchase-required videos) were being retried 3× unnecessarily before failing. They are now caught as non-retryable and return immediately with a warning log.

**2. Statistics label confusion (bug fix)**
The "Transcripts ✗" count in Admin Statistics could exceed the videos collection count because it includes items later AI-excluded or failed at other pipeline steps — not just final videos. Renamed to "Transcript Failures" with an explanatory tooltip.

**3. Future date display (bug fix)**
DateHelper.FormatDateRelative produced "-4 days ago" for future-dated content. Now correctly shows "Tomorrow", "In X days", or "In X weeks".

**4. Admin date editing (new feature)**
Admins can now update the publication date of any content item directly from the editor modal. The date change is propagated atomically to both content_items and the denormalized content_tags_expanded table.

**5. Future date cap in pipeline**
Future-dated items ingested from feeds are capped to the processing timestamp, ensuring they are not excluded from weekly roundups (which filter by date range relative to run time).

## Technical Changes

- YouTubeTranscriptService: catch VideoUnavailableException/VideoUnplayableException before the generic retry handler
- AdminStatistics.razor: rename stat card + add tooltip
- DateHelper.FormatDateRelative: handle negative daysDiff for future dates
- ContentItemEditData: add DateEpoch property
- ContentItemEditorModal.razor: add DateOnly? bound date picker; convert to/from epoch on load/save
- ContentRepository.UpdateEditDataAsync: include date_epoch in the UPDATE; sync content_tags_expanded after update
- AdminEndpoints: validate DateEpoch > 0 on update
- ProcessedContentItem: add WithDateEpoch() copy method
- ContentProcessingService: cap future dates to _timeProvider.GetUtcNow() + log transcript unavailability
- ContentProcessingServiceTests: restore FrozenTimeProvider and future date cap integration test
- AdminEndpointsTests: add DateEpoch to the edit data fixture
