### PR TITLE
Fix E2E test timeouts: always inject __e2e signals and remove bail-out

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -238,7 +238,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
-          skip-dirs: 'node_modules,.tmp,scripts/data/rss-cache'
+          skip-dirs: 'node_modules,.tmp'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
@@ -637,7 +637,7 @@ jobs:
       - name: Install Playwright dependencies
         run: |
           cd tests/TechHub.E2E.Tests
-          pwsh bin/Release/net10.0/playwright.ps1 install --with-deps
+          pwsh bin/Release/net10.0/playwright.ps1 install chrome --with-deps
 
       - name: Wait for deployment to stabilize
         run: sleep 60

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -238,7 +238,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
-          skip-dirs: 'node_modules,.tmp'
+          skip-dirs: 'node_modules,.tmp,scripts/data/rss-cache'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
-          skip-dirs: 'node_modules,.tmp'
+          skip-dirs: 'node_modules,.tmp,scripts/data/rss-cache'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
-          skip-dirs: 'node_modules,.tmp,scripts/data/rss-cache'
+          skip-dirs: 'node_modules,.tmp'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
@@ -598,7 +598,7 @@ jobs:
       - name: Install Playwright dependencies
         run: |
           cd tests/TechHub.E2E.Tests
-          pwsh bin/Release/net10.0/playwright.ps1 install --with-deps
+          pwsh bin/Release/net10.0/playwright.ps1 install chrome --with-deps
 
       - name: Run E2E tests against PR preview
         run: |

--- a/src/TechHub.Web/Components/App.razor
+++ b/src/TechHub.Web/Components/App.razor
@@ -40,33 +40,28 @@
     @{
         var appInsightsConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
         var isDevelopment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development";
-        // E2E signals are enabled in Development AND Staging — Staging is where CI/PR E2E tests run.
-        // Production excludes them (zero overhead, no test tooling in prod).
-        var enableE2ESignals = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") is "Development" or "Staging";
         var gaMeasurementId = Configuration["GoogleAnalytics:MeasurementId"];
     }
 
-    @if (enableE2ESignals)
-    {
-        <!-- E2E test lifecycle counter — provides a single monotonic counter that
-             all JS lifecycle hooks increment via __e2eSignal(label). Tests capture
-             the counter before an action and wait for it to change, replacing 8+
-             independent window.__* flags with one universal wait pattern.
-             Enabled in Development and Staging (CI/PR preview E2E tests run there). -->
-        <script>
-            if (!window.__e2e) {
-                window.__e2e = { counter: 0, label: 'init', history: [] };
-                window.__e2eSignal = function(label) {
-                    if (!window.__e2e) return;
-                    window.__e2e.counter++;
-                    window.__e2e.label = label;
-                    window.__e2e.history.push({ counter: window.__e2e.counter, label: label });
-                    if (window.__e2e.history.length > 20) window.__e2e.history.shift();
-                };
-                window.addEventListener('scrollend', function() { window.__e2eSignal('scroll-end'); });
-            }
-        </script>
-    }
+    <!-- E2E test lifecycle counter — provides a single monotonic counter that
+         all JS lifecycle hooks increment via __e2eSignal(label). Tests capture
+         the counter before an action and wait for it to change, replacing 8+
+         independent window.__* flags with one universal wait pattern.
+         Always enabled: trivial overhead (~200 bytes), no security risk, and ensures
+         E2E tests behave identically regardless of target environment. -->
+    <script>
+        if (!window.__e2e) {
+            window.__e2e = { counter: 0, label: 'init', history: [] };
+            window.__e2eSignal = function(label) {
+                if (!window.__e2e) return;
+                window.__e2e.counter++;
+                window.__e2e.label = label;
+                window.__e2e.history.push({ counter: window.__e2e.counter, label: label });
+                if (window.__e2e.history.length > 20) window.__e2e.history.shift();
+            };
+            window.addEventListener('scrollend', function() { window.__e2eSignal('scroll-end'); });
+        }
+    </script>
 
     @if (!isDevelopment && !string.IsNullOrEmpty(gaMeasurementId))
     {

--- a/tests/TechHub.E2E.Tests/Helpers/BlazorHelpers.cs
+++ b/tests/TechHub.E2E.Tests/Helpers/BlazorHelpers.cs
@@ -574,24 +574,7 @@ public static class BlazorHelpers
                     // Step 1: Blazor runtime must exist
                     if (typeof window.Blazor === 'undefined') return false;
 
-                    // Step 2: If web started but server circuit hasn't connected, optionally bail out.
-                    //
-                    // LOCAL/DEV/STAGING: If window.__e2e is present (Development + Staging have it),
-                    // we know we're in an E2E-tracked environment. NEVER bail out early — wait for the
-                    // circuit to fully establish (up to E2ETimeout). This is critical for remote
-                    // deployments (e.g., PR previews in Azure Sweden Central) where higher network
-                    // latency means the Blazor Server circuit can take >5s to establish.
-                    // Bailing out early would cause tests to click before @onclick handlers attach.
-                    //
-                    // PRODUCTION (no __e2e): Bail out after 5s. These tests only inspect SSR DOM
-                    // (URLs, meta tags, layout) and don't need @onclick handlers. Without this bail-out
-                    // every content detail test that genuinely cannot establish a circuit would wait
-                    // the full 60s timeout.
-                    if (!window.__e2e && window.__blazorWebReadyAt && !window.__blazorServerReady && !window.__blazorWasmReady) {
-                        if (Date.now() - window.__blazorWebReadyAt > 5000) return true;
-                    }
-
-                    // Step 3: Interactive Server/WASM circuit must be established.
+                    // Step 2: Interactive Server/WASM circuit must be established.
                     // __blazorServerReady is set by afterServerStarted() — SignalR circuit ready, event handlers attached.
                     // __blazorWasmReady  is set by afterWebAssemblyStarted() — WASM runtime ready.
                     // NOTE: __blazorWebReady (afterWebStarted) fires too early — before the interactive circuit
@@ -600,14 +583,14 @@ public static class BlazorHelpers
                         return false;
                     }
 
-                    // Step 4: Page scripts must not be actively loading
+                    // Step 3: Page scripts must not be actively loading
                     // __scriptsLoading is set true by markScriptsLoading() when page scripts start,
                     // and set false by markScriptsReady() when they complete.
                     // Only block if scripts are ACTIVELY loading. If both flags are undefined,
                     // the page has no page scripts (e.g., SectionCollection.razor) — proceed immediately.
                     if (window.__scriptsLoading === true) return false;
 
-                    // Step 5: Mermaid diagrams rendered (if present)
+                    // Step 4: Mermaid diagrams rendered (if present)
                     // Only wait if page has <pre class='mermaid'> elements that haven't been converted to SVG yet
                     const mermaidPres = document.querySelectorAll('pre.mermaid');
                     if (mermaidPres.length > 0) {


### PR DESCRIPTION
## Problem

E2E tests in \cd.yml\ (production) were timing out massively. Tests would click elements before \@onclick\ handlers were attached, causing cascading failures.

## Root Cause

\WaitForBlazorReadyAsync\ had a 5-second bail-out that returned \	rue\ (pretending ready) when \window.__e2e\ was absent. In production, \__e2e\ was never injected (only Development/Staging had it), so:

1. After SSR completes, \__blazorWebReadyAt\ is set
2. SignalR circuit takes >5s to connect in Azure (network latency)
3. Bail-out fires → returns \	rue\ → test proceeds
4. Clicks fail because \@onclick\ handlers aren't attached yet

PR preview (\ci.yml\) worked fine because it runs in Staging mode → has \__e2e\ → bail-out never fires → waits full 60s for circuit.

## Fix

1. **App.razor**: Always inject the \__e2e\ lifecycle counter in all environments. It's ~200 bytes with zero security risk — just a monotonic counter for test observability.

2. **BlazorHelpers.cs**: Remove the bail-out entirely. Tests now always wait for the actual SignalR circuit to establish (up to 60s timeout), ensuring identical behavior across all environments.

3. **CI/CD workflows** *(from prior commit)*: Use \playwright install chrome --with-deps\ to align CI Chrome with the devcontainer version.

## Testing

- All unit/integration tests pass (\Run -SkipE2E\)
- The fix ensures E2E tests behave identically whether targeting PR preview or production