### PR TITLE
Bump dependencies: YamlDotNet, Aspire, trivy-action + group all Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,34 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"
 
   - package-ecosystem: nuget
     directory: /
     schedule:
       interval: weekly
+    groups:
+      nuget-all:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
+    groups:
+      npm-all:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    groups:
+      docker-all:
+        patterns:
+          - "*"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -230,7 +230,7 @@ jobs:
           dotnet list TechHub.slnx package --vulnerable --include-transitive
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
           dotnet list TechHub.slnx package --vulnerable --include-transitive
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
-    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+    <PackageVersion Include="YamlDotNet" Version="17.1.0" />
     <PackageVersion Include="YoutubeExplode" Version="6.6.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.3" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.4" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="Dapper" Version="2.1.72" />


### PR DESCRIPTION
Bundles the 3 open Dependabot PRs (#369, #370, #371) into a single PR and configures Dependabot to group all future updates per ecosystem into one PR each.

## Changes
- Bump YamlDotNet from 16.3.0 to 17.1.0
- Bump Aspire.Hosting.AppHost from 13.2.3 to 13.2.4
- Bump aquasecurity/trivy-action from 0.35.0 to 0.36.0
- Configure Dependabot \groups\ for all 4 ecosystems (nuget, github-actions, npm, docker) so future updates are bundled into one PR per ecosystem

Closes #369, closes #370, closes #371