### PR TITLE
fix: Improve App Insights failure visibility and production stability

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -634,33 +634,17 @@ jobs:
           echo "**Web**: https://${{ steps.deploy.outputs.web-url }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Create Application Insights release annotation
-        shell: bash
+        shell: pwsh
         run: |
-          ANNOTATION_ID="${{ github.run_id }}"
-          RELEASE_NAME="${{ needs.build-and-push.outputs.image-tag }}"
-          COMMIT="${{ github.sha }}"
-          DEPLOYED_BY="${{ github.actor }}"
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-          # The 2015-05-01 API requires Properties to be a JSON-encoded string, not a nested object.
-          PROPERTIES=$(jq -cn \
-            --arg rel "$RELEASE_NAME" \
-            --arg commit "$COMMIT" \
-            --arg by "$DEPLOYED_BY" \
-            --arg url "$RUN_URL" \
-            '{"ReleaseName":$rel,"Commit":$commit,"DeployedBy":$by,"RunUrl":$url}')
-
-          ANNOTATION_BODY=$(jq -cn \
-            --arg id "$ANNOTATION_ID" \
-            --arg name "Release $RELEASE_NAME" \
-            --arg time "$(date -u +%Y-%m-%dT%H:%M:%S.0000000Z)" \
-            --arg props "$PROPERTIES" \
-            '{"Id":$id,"AnnotationName":$name,"EventTime":$time,"Properties":$props}')
-
-          az rest --method put \
-            --headers "Content-Type=application/json" \
-            --url "https://management.azure.com/subscriptions/bc8ab567-c645-4e51-9317-992203eb369a/resourceGroups/rg-techhub-prod/providers/Microsoft.Insights/components/appi-techhub-prod/Annotations/${ANNOTATION_ID}?api-version=2015-05-01" \
-            --body "$ANNOTATION_BODY"
+          ./scripts/Add-AppInsightsAnnotation.ps1 `
+            -SubscriptionId "bc8ab567-c645-4e51-9317-992203eb369a" `
+            -ResourceGroupName "rg-techhub-prod" `
+            -AppInsightsName "appi-techhub-prod" `
+            -AnnotationId "${{ github.run_id }}" `
+            -ReleaseName "${{ needs.build-and-push.outputs.image-tag }}" `
+            -Commit "${{ github.sha }}" `
+            -DeployedBy "${{ github.actor }}" `
+            -RunUrl "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   # ──────────────────────────────────────────────
   # Production E2E tests — run after deployment

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -103,7 +103,7 @@ Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
 
 This makes the span appear on the **Failures** blade in Application Insights, enabling monitoring of how often users hit non-existent URLs. The description is always `"Content not found"` regardless of the URL, so the failure can be grouped and trended by operation name.
 
-> **Note**: Single-segment URLs handled entirely by `UrlNormalizationMiddleware` (returning HTTP 404 directly) are automatically tracked as failures by ASP.NET Core request tracing — no extra code needed. The `Activity.SetStatus` calls above cover the in-page cases where the response status remains 200.
+> **Note**: Single-segment URLs handled entirely by `UrlNormalizationMiddleware` (returning HTTP 404 directly) are automatically tracked as failures by ASP.NET Core request tracing — no extra code needed. The `Activity.SetStatus` calls above cover the in-page cases where the Blazor component renders inline not-found content (the `NotFoundContent` component also sets `HttpContext.Response.StatusCode = 404` during SSR prerendering, so the HTTP response carries a real 404 for crawlers even in those cases).
 
 Bot-generated not-found spans are suppressed by `TelemetryNoiseProcessor` (see [src/TechHub.ServiceDefaults/TelemetryNoiseProcessor.cs](../src/TechHub.ServiceDefaults/TelemetryNoiseProcessor.cs)), so bot traffic does not inflate the failure rate.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -93,6 +93,20 @@ Alerts are created with an empty actions list — add an action group in the Azu
 
 Tests are only created when `primaryHosts` is non-empty in the Bicep deployment. If no custom hostnames are provided, no availability tests or alerts are created.
 
+## Not-Found Failure Tracking
+
+All pages that render "not found" content inline (content-item pages, custom pages, and layout-level invalid-section errors) mark their OpenTelemetry span as failed with:
+
+```csharp
+Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+```
+
+This makes the span appear on the **Failures** blade in Application Insights, enabling monitoring of how often users hit non-existent URLs. The description is always `"Content not found"` regardless of the URL, so the failure can be grouped and trended by operation name.
+
+> **Note**: Single-segment URLs handled entirely by `UrlNormalizationMiddleware` (returning HTTP 404 directly) are automatically tracked as failures by ASP.NET Core request tracing — no extra code needed. The `Activity.SetStatus` calls above cover the in-page cases where the response status remains 200.
+
+Bot-generated not-found spans are suppressed by `TelemetryNoiseProcessor` (see [src/TechHub.ServiceDefaults/TelemetryNoiseProcessor.cs](../src/TechHub.ServiceDefaults/TelemetryNoiseProcessor.cs)), so bot traffic does not inflate the failure rate.
+
 ## Google Analytics
 
 GA4 is active in Production only (controlled by `GoogleAnalytics:MeasurementId` in `appsettings.Production.json`).

--- a/docs/url-routing.md
+++ b/docs/url-routing.md
@@ -84,7 +84,9 @@ For all other single-segment paths, calls `GET /api/legacy-redirect?slug={slug}&
 
 **Case is not normalized in the middleware.** The infrastructure layer lowercases parameters before DB queries, so `/My-Article` and `/my-article` both resolve to the same content without a redirect.
 
-**Not found**: if the API returns no match, or if the API is unavailable after retries (see [architecture.md](architecture.md)), the middleware returns a **404** immediately. There is no redirect to a cleaned path — the cleaned URL has already been applied upstream by normalizations, so no extra round-trip is needed.
+**Not found**: if the API returns no match, the middleware returns a **404** immediately. There is no redirect to a cleaned path — the cleaned URL has already been applied upstream by normalizations, so no extra round-trip is needed.
+
+**Transient API failure**: if the API is temporarily unavailable (network error or timeout after all retries), the middleware degrades gracefully instead of returning a cacheable 404 that could mislabel a valid legacy URL as permanently absent. When the path was cleaned (`pathChanged = true`), the middleware still issues a **301 redirect** to the normalized URL. When the path was already clean, the request is passed through to Blazor routing. In both cases the failure is logged as a warning.
 
 ## Stage 3 — HTTPS Redirect
 

--- a/docs/url-routing.md
+++ b/docs/url-routing.md
@@ -84,7 +84,7 @@ For all other single-segment paths, calls `GET /api/legacy-redirect?slug={slug}&
 
 **Case is not normalized in the middleware.** The infrastructure layer lowercases parameters before DB queries, so `/My-Article` and `/my-article` both resolve to the same content without a redirect.
 
-**Fallback**: if the API returns no match but the URL was changed by normalizations, the request is still redirected to the cleaned path. If the API is unavailable, the same fallback applies — `.html` and date prefixes are always cleaned.
+**Not found**: if the API returns no match, or if the API is unavailable after retries (see [architecture.md](architecture.md)), the middleware returns a **404** immediately. There is no redirect to a cleaned path — the cleaned URL has already been applied upstream by normalizations, so no extra round-trip is needed.
 
 ## Stage 3 — HTTPS Redirect
 

--- a/scripts/Add-AppInsightsAnnotation.ps1
+++ b/scripts/Add-AppInsightsAnnotation.ps1
@@ -1,0 +1,76 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SubscriptionId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ResourceGroupName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$AppInsightsName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$AnnotationId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Commit,
+
+    [Parameter(Mandatory = $true)]
+    [string]$DeployedBy,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RunUrl,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorkspaceDirectory = $PSScriptRoot
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+try {
+    Write-Host "Creating Application Insights release annotation..."
+    Write-Host "  App Insights: $AppInsightsName"
+    Write-Host "  Release:      $ReleaseName"
+    Write-Host "  Commit:       $Commit"
+
+    # The 2015-05-01 API requires Properties to be a JSON-encoded string, not a nested object.
+    # It also requires a non-null Category field.
+    $propertiesObject = [ordered]@{
+        ReleaseName = $ReleaseName
+        Commit      = $Commit
+        DeployedBy  = $DeployedBy
+        RunUrl      = $RunUrl
+    }
+    $propertiesJson = $propertiesObject | ConvertTo-Json -Compress
+
+    $eventTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.0000000Z")
+
+    $annotationBody = [ordered]@{
+        Id             = $AnnotationId
+        AnnotationName = "Release $ReleaseName"
+        EventTime      = $eventTime
+        Category       = "Deployment"
+        Properties     = $propertiesJson
+    }
+    $annotationBodyJson = $annotationBody | ConvertTo-Json -Compress
+
+    $url = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.Insights/components/$AppInsightsName/Annotations/$($AnnotationId)?api-version=2015-05-01"
+
+    az rest --method put `
+        --headers "Content-Type=application/json" `
+        --url $url `
+        --body $annotationBodyJson
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "az rest failed with exit code $LASTEXITCODE"
+    }
+
+    Write-Host "Release annotation created successfully."
+}
+catch {
+    Write-Error "Failed to create Application Insights release annotation: $_"
+    exit 1
+}

--- a/src/TechHub.Api/appsettings.json
+++ b/src/TechHub.Api/appsettings.json
@@ -6,7 +6,7 @@
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.IdentityModel": "Warning",
       "System.Net.Http.HttpClient": "Warning",
-      "Polly": "Warning"
+      "Polly": "Error"
     },
     "File": {
       "LogLevel": {

--- a/src/TechHub.Web/Components/ContentItemsGrid.razor
+++ b/src/TechHub.Web/Components/ContentItemsGrid.razor
@@ -291,27 +291,27 @@
             return;
         }
 
-        // When restoring from circuit cache (back-button navigation), suppress the
-        // immediate trigger check in infinite-scroll.js to prevent a cascade of batch
-        // loads. The generic scroll restore in nav-helpers.js handles position restoration
-        // via markScriptsReady — we just need to prevent the cascade here.
-        if (needsScrollRestore)
-        {
-            needsScrollRestore = false;
-            scrollModule ??= await JSRuntime.InvokeAsync<IJSObjectReference>(
-                "import", "/js/infinite-scroll.js");
-            await scrollModule.InvokeVoidAsync("setSuppressNextTriggerCheck");
-        }
-
-        // Setup scroll listener on first render, or re-attach when filters change
+        // Setup scroll listener on first render, or re-attach when filters change.
+        // When restoring from circuit cache (back-button navigation), pass suppressRestore=true
+        // so observeScrollTrigger atomically sets the anti-cascade suppress flag AND attaches
+        // the listener in a single JS call. This eliminates the two-call race where
+        // SectionCollection.OnAfterRenderAsync could call markScriptsReady() between the old
+        // separate setSuppressNextTriggerCheck() and observeScrollTrigger() interop calls.
         if ((firstRender || needsScrollListenerSetup) && hasMoreContent)
         {
+            var suppressRestore = needsScrollRestore;
+            needsScrollRestore = false;
             needsScrollListenerSetup = false;
-            await SetupScrollListener();
+            await SetupScrollListener(suppressRestore);
+        }
+        else if (needsScrollRestore)
+        {
+            // hasMoreContent is false — no scroll trigger to attach, but clear the flag.
+            needsScrollRestore = false;
         }
     }
 
-    private async Task SetupScrollListener()
+    private async Task SetupScrollListener(bool suppressRestore = false)
     {
         try
         {
@@ -323,8 +323,10 @@
             dotNetRef ??= DotNetObjectReference.Create(this);
 
             // (Re-)attach scroll listener to current scroll-trigger element.
+            // Pass suppressRestore=true on back-navigation to atomically set the
+            // anti-cascade flag inside observeScrollTrigger (no separate JS call needed).
             // JS dispose() handles cleanup of previous listener.
-            await scrollModule.InvokeVoidAsync("observeScrollTrigger", dotNetRef, "scroll-trigger");
+            await scrollModule.InvokeVoidAsync("observeScrollTrigger", dotNetRef, "scroll-trigger", suppressRestore);
             Logger.LogDebug("Infinite scroll listener attached");
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/ContentItemsGrid.razor
+++ b/src/TechHub.Web/Components/ContentItemsGrid.razor
@@ -292,17 +292,17 @@
         }
 
         // Setup scroll listener on first render, or re-attach when filters change.
-        // When restoring from circuit cache (back-button navigation), pass suppressRestore=true
+        // When restoring from circuit cache (back-button navigation), pass suppressOnAttach=true
         // so observeScrollTrigger atomically sets the anti-cascade suppress flag AND attaches
         // the listener in a single JS call. This eliminates the two-call race where
         // SectionCollection.OnAfterRenderAsync could call markScriptsReady() between the old
         // separate setSuppressNextTriggerCheck() and observeScrollTrigger() interop calls.
         if ((firstRender || needsScrollListenerSetup) && hasMoreContent)
         {
-            var suppressRestore = needsScrollRestore;
+            var suppressOnAttach = needsScrollRestore;
             needsScrollRestore = false;
             needsScrollListenerSetup = false;
-            await SetupScrollListener(suppressRestore);
+            await SetupScrollListener(suppressOnAttach);
         }
         else if (needsScrollRestore)
         {
@@ -311,7 +311,7 @@
         }
     }
 
-    private async Task SetupScrollListener(bool suppressRestore = false)
+    private async Task SetupScrollListener(bool suppressOnAttach = false)
     {
         try
         {
@@ -323,10 +323,10 @@
             dotNetRef ??= DotNetObjectReference.Create(this);
 
             // (Re-)attach scroll listener to current scroll-trigger element.
-            // Pass suppressRestore=true on back-navigation to atomically set the
+            // Pass suppressOnAttach=true on back-navigation to atomically set the
             // anti-cascade flag inside observeScrollTrigger (no separate JS call needed).
             // JS dispose() handles cleanup of previous listener.
-            await scrollModule.InvokeVoidAsync("observeScrollTrigger", dotNetRef, "scroll-trigger", suppressRestore);
+            await scrollModule.InvokeVoidAsync("observeScrollTrigger", dotNetRef, "scroll-trigger", suppressOnAttach);
             Logger.LogDebug("Infinite scroll listener attached");
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Layout/MainLayout.razor
+++ b/src/TechHub.Web/Components/Layout/MainLayout.razor
@@ -15,7 +15,11 @@
         CustomBannerTitle="@_customBannerTitle"
         CustomBannerDescription="@_customBannerDescription" />
 
-@if (!_isInvalid)
+@if (_isInvalid)
+{
+    <NotFoundContent />
+}
+else
 {
     @Body
 }
@@ -111,7 +115,9 @@
                     if (!validCollection)
                     {
                         _isInvalid = true;
-                        Navigation.NavigateTo("/not-found");
+                        _customBannerTitle = "Not Found";
+                        _customBannerDescription = "Sorry, the content you are looking for does not exist";
+                        Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
                         return;
                     }
                 }
@@ -123,11 +129,13 @@
             }
 
             // First segment is not a known section. If it's not a fixed page either,
-            // it's an invalid route — redirect to /not-found.
+            // render not-found content inline at the original URL.
             if (!KnownNonSectionPages.Contains(firstSegment))
             {
                 _isInvalid = true;
-                Navigation.NavigateTo("/not-found");
+                _customBannerTitle = "Not Found";
+                _customBannerDescription = "Sorry, the content you are looking for does not exist";
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
                 return;
             }
         }

--- a/src/TechHub.Web/Components/NotFoundContent.razor
+++ b/src/TechHub.Web/Components/NotFoundContent.razor
@@ -1,0 +1,5 @@
+<main class="page-without-sidebar">
+    <section>
+        <p><a href="/" class="back-link">← Back to Home</a></p>
+    </section>
+</main>

--- a/src/TechHub.Web/Components/NotFoundContent.razor
+++ b/src/TechHub.Web/Components/NotFoundContent.razor
@@ -1,5 +1,37 @@
+@using Microsoft.AspNetCore.Http
+@inject IJSRuntime JS
+
 <main class="page-without-sidebar">
     <section>
         <p><a href="/" class="back-link">← Back to Home</a></p>
     </section>
 </main>
+
+@code {
+    /// <summary>
+    /// Available during SSR prerendering; null during interactive SignalR rendering.
+    /// Used to set the HTTP 404 status code on the server response so crawlers and
+    /// monitoring tools see a real 404 instead of a 200 with not-found content.
+    /// </summary>
+    [CascadingParameter]
+    private HttpContext? HttpContext { get; set; }
+
+    protected override void OnInitialized()
+    {
+        if (HttpContext is not null)
+        {
+            HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            // Required for scroll-position restoration on back/forward navigation.
+            // Called here (rather than only in page components) so layouts that render
+            // <NotFoundContent /> directly (e.g. when _isInvalid is true) also signal readiness.
+            await JS.InvokeVoidAsync("markScriptsReady");
+        }
+    }
+}

--- a/src/TechHub.Web/Components/NotFoundContent.razor
+++ b/src/TechHub.Web/Components/NotFoundContent.razor
@@ -1,4 +1,3 @@
-@using Microsoft.AspNetCore.Http
 @inject IJSRuntime JS
 
 <main class="page-without-sidebar">

--- a/src/TechHub.Web/Components/NotFoundContent.razor
+++ b/src/TechHub.Web/Components/NotFoundContent.razor
@@ -2,6 +2,8 @@
 
 <main class="page-without-sidebar">
     <section>
+        <h1 id="skiptohere" class="page-h1">Page Not Found</h1>
+        <p>Sorry, the content you are looking for does not exist or has been moved.</p>
         <p><a href="/" class="back-link">← Back to Home</a></p>
     </section>
 </main>

--- a/src/TechHub.Web/Components/Pages/AISDLC.razor
+++ b/src/TechHub.Web/Components/Pages/AISDLC.razor
@@ -242,9 +242,14 @@
         </article>
     </main>
 }
+else if (_notFound)
+{
+    <NotFoundContent />
+}
 
 @code {
     private SDLCPageData? pageData;
+    private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
 
     private string GetRenderedContent()
@@ -276,18 +281,19 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (pageData != null)
+        try
         {
-            try
+            // Single-route page; scripts only need to init once
+            if (firstRender && pageData != null)
             {
                 await JS.InvokeVoidAsync("markScriptsLoading");
                 await JS.InvokeVoidAsync("initMermaid");
                 await JS.InvokeVoidAsync("initTocScrollSpy");
             }
-            finally
-            {
-                await JS.InvokeVoidAsync("markScriptsReady");
-            }
+        }
+        finally
+        {
+            await JS.InvokeVoidAsync("markScriptsReady");
         }
     }
 
@@ -307,7 +313,8 @@
 
             if (pageData == null)
             {
-                Navigation.NavigateTo("/not-found");
+                _notFound = true;
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/AISDLC.razor
+++ b/src/TechHub.Web/Components/Pages/AISDLC.razor
@@ -252,6 +252,9 @@ else if (_notFound)
     private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
 
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
     private string GetRenderedContent()
     {
         if (pageData == null)
@@ -315,6 +318,10 @@ else if (_notFound)
             {
                 _notFound = true;
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/ContentItem.razor
+++ b/src/TechHub.Web/Components/Pages/ContentItem.razor
@@ -86,6 +86,9 @@ else
     private string? _previousCollectionName;
     private string? _previousSlug;
 
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         try
@@ -112,6 +115,10 @@ else
             || !RouteParameterValidator.IsValidSlug(Slug))
         {
             Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+            if (HttpContext is not null)
+            {
+                HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+            }
             isLoading = false;
             return;
         }
@@ -120,6 +127,11 @@ else
         section = SectionCache.GetSectionByName(SectionName);
         if (section == null)
         {
+            Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+            if (HttpContext is not null)
+            {
+                HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+            }
             isLoading = false;
             return;
         }
@@ -152,6 +164,10 @@ else
                 || !RouteParameterValidator.IsValidSlug(Slug))
             {
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
                 isLoading = false;
                 return;
             }
@@ -159,6 +175,11 @@ else
             section = SectionCache.GetSectionByName(SectionName);
             if (section == null)
             {
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
                 isLoading = false;
                 return;
             }
@@ -187,6 +208,10 @@ else
             {
                 // Content not found - the template renders not-found content inline.
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/ContentItem.razor
+++ b/src/TechHub.Web/Components/Pages/ContentItem.razor
@@ -9,7 +9,14 @@
 @inject ITechHubApiClient ApiClient
 @inject NavigationManager Navigation
 
-<PageTitle>@(item?.Title ?? (isLoading ? "" : "Not Found")) - Tech Hub</PageTitle>
+<PageTitle>@(item?.Title ?? "Not Found") - Tech Hub</PageTitle>
+
+@if (!isLoading && item == null)
+{
+    <NotFoundContent />
+}
+else
+{
 
 @if (item != null)
 {
@@ -51,15 +58,9 @@
     {
         <ContentItemDetail Item="@item" />
     }
-    else if (!isLoading)
-    {
-        <section>
-            <h1>Not Found</h1>
-            <p>Sorry, the content you are looking for does not exist.</p>
-            <p><a href="/" class="back-link">← Back to Home</a></p>
-        </section>
-    }
 </main>
+
+}
 
 @code {
     [Inject] public required ErrorService ErrorService { get; set; }
@@ -87,19 +88,19 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (item != null)
+        try
         {
-            try
+            if (item != null)
             {
                 await JS.InvokeVoidAsync("markScriptsLoading");
                 await JS.InvokeVoidAsync("initHighlighting");
                 await JS.InvokeVoidAsync("initMermaid");
                 await JS.InvokeVoidAsync("initTocScrollSpy");
             }
-            finally
-            {
-                await JS.InvokeVoidAsync("markScriptsReady");
-            }
+        }
+        finally
+        {
+            await JS.InvokeVoidAsync("markScriptsReady");
         }
     }
 
@@ -110,7 +111,7 @@
             || !RouteParameterValidator.IsValidNameSegment(CollectionName)
             || !RouteParameterValidator.IsValidSlug(Slug))
         {
-            Navigation.NavigateTo("/not-found");
+            isLoading = false;
             return;
         }
 
@@ -118,7 +119,7 @@
         section = SectionCache.GetSectionByName(SectionName);
         if (section == null)
         {
-            Navigation.NavigateTo("/not-found");
+            isLoading = false;
             return;
         }
 
@@ -149,14 +150,14 @@
                 || !RouteParameterValidator.IsValidNameSegment(CollectionName)
                 || !RouteParameterValidator.IsValidSlug(Slug))
             {
-                Navigation.NavigateTo("/not-found");
+                isLoading = false;
                 return;
             }
 
             section = SectionCache.GetSectionByName(SectionName);
             if (section == null)
             {
-                Navigation.NavigateTo("/not-found");
+                isLoading = false;
                 return;
             }
 
@@ -182,8 +183,8 @@
 
             if (item == null)
             {
-                // Content not found - navigate to not found page
-                Navigation.NavigateTo("/not-found");
+                // Content not found - the template renders not-found content inline.
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/ContentItem.razor
+++ b/src/TechHub.Web/Components/Pages/ContentItem.razor
@@ -163,6 +163,7 @@ else
                 || !RouteParameterValidator.IsValidNameSegment(CollectionName)
                 || !RouteParameterValidator.IsValidSlug(Slug))
             {
+                item = null;
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
                 if (HttpContext is not null)
                 {
@@ -175,6 +176,7 @@ else
             section = SectionCache.GetSectionByName(SectionName);
             if (section == null)
             {
+                item = null;
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
                 if (HttpContext is not null)
                 {

--- a/src/TechHub.Web/Components/Pages/ContentItem.razor
+++ b/src/TechHub.Web/Components/Pages/ContentItem.razor
@@ -111,6 +111,7 @@ else
             || !RouteParameterValidator.IsValidNameSegment(CollectionName)
             || !RouteParameterValidator.IsValidSlug(Slug))
         {
+            Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
             isLoading = false;
             return;
         }
@@ -150,6 +151,7 @@ else
                 || !RouteParameterValidator.IsValidNameSegment(CollectionName)
                 || !RouteParameterValidator.IsValidSlug(Slug))
             {
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
                 isLoading = false;
                 return;
             }

--- a/src/TechHub.Web/Components/Pages/DXSpace.razor
+++ b/src/TechHub.Web/Components/Pages/DXSpace.razor
@@ -357,9 +357,14 @@
         </article>
     </main>
 }
+else if (_notFound)
+{
+    <NotFoundContent />
+}
 
 @code {
     private DXSpacePageData? pageData;
+    private bool _notFound;
 
     private string GetRenderedContent()
     {
@@ -416,10 +421,17 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (pageData != null)
+        try
         {
-            await JS.InvokeVoidAsync("markScriptsLoading");
-            await JS.InvokeVoidAsync("initTocScrollSpy");
+            // Single-route page; scripts only need to init once
+            if (firstRender && pageData != null)
+            {
+                await JS.InvokeVoidAsync("markScriptsLoading");
+                await JS.InvokeVoidAsync("initTocScrollSpy");
+            }
+        }
+        finally
+        {
             await JS.InvokeVoidAsync("markScriptsReady");
         }
     }
@@ -440,7 +452,8 @@
 
             if (pageData == null)
             {
-                Navigation.NavigateTo("/not-found");
+                _notFound = true;
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/DXSpace.razor
+++ b/src/TechHub.Web/Components/Pages/DXSpace.razor
@@ -366,6 +366,9 @@ else if (_notFound)
     private DXSpacePageData? pageData;
     private bool _notFound;
 
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
     private string GetRenderedContent()
     {
         if (pageData == null)
@@ -454,6 +457,10 @@ else if (_notFound)
             {
                 _notFound = true;
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GenAI.razor
+++ b/src/TechHub.Web/Components/Pages/GenAI.razor
@@ -12,7 +12,7 @@
 @inject ILogger<GenAI> Logger
 @inject PersistentComponentState ApplicationState
 
-<PageTitle>@(pageData?.Title ?? PageType) - Tech Hub</PageTitle>
+<PageTitle>@GetPageTitle() - Tech Hub</PageTitle>
 
 @if (pageData != null)
 {
@@ -91,12 +91,25 @@
         </article>
     </main>
 }
+else if (_notFound)
+{
+    <NotFoundContent />
+}
 
 @code {
     private GenAIPageData? pageData;
+    private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
     private string? _previousPageType;
     private string PageType => DeterminePageType();
+
+    private string GetPageTitle() => pageData?.Title ?? PageType switch
+    {
+        "basics" => "GenAI Basics",
+        "applied" => "GenAI Applied",
+        "advanced" => "GenAI Advanced",
+        _ => "AI in Practice"
+    };
 
     /// <summary>
     /// Determine which page type based on current route
@@ -152,19 +165,19 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (pageData != null)
+        try
         {
-            try
+            if (pageData != null)
             {
                 await JS.InvokeVoidAsync("markScriptsLoading");
                 await JS.InvokeVoidAsync("initHighlighting");
                 await JS.InvokeVoidAsync("initMermaid");
                 await JS.InvokeVoidAsync("initTocScrollSpy");
             }
-            finally
-            {
-                await JS.InvokeVoidAsync("markScriptsReady");
-            }
+        }
+        finally
+        {
+            await JS.InvokeVoidAsync("markScriptsReady");
         }
     }
 
@@ -223,7 +236,8 @@
 
             if (pageData == null)
             {
-                Navigation.NavigateTo("/not-found");
+                _notFound = true;
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GenAI.razor
+++ b/src/TechHub.Web/Components/Pages/GenAI.razor
@@ -103,6 +103,9 @@ else if (_notFound)
     private string? _previousPageType;
     private string PageType => DeterminePageType();
 
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
     private string GetPageTitle() => pageData?.Title ?? PageType switch
     {
         "basics" => "GenAI Basics",
@@ -238,6 +241,10 @@ else if (_notFound)
             {
                 _notFound = true;
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotFeatures.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotFeatures.razor
@@ -161,6 +161,9 @@ else if (_notFound)
     private List<TechHub.Core.Models.ContentItem> videoItems = new();
     private PersistingComponentStateSubscription? _persistSubscription;
 
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
     // Per-section active filters — keyed by featureSection.Id.
     // Each section maintains its own independent filter state.
     private readonly Dictionary<string, HashSet<string>> _sectionFilters = new();
@@ -241,6 +244,10 @@ else if (_notFound)
             {
                 _notFound = true;
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
                 return;
             }
 

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotFeatures.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotFeatures.razor
@@ -147,12 +147,17 @@
         </article>
     </main>
 }
+else if (_notFound)
+{
+    <NotFoundContent />
+}
 
 @code {
     private const string SectionName = "github-copilot";
     private const string FilterGhes = "ghes";
     private const string FilterVideos = "videos";
     private FeaturesPageData? pageData;
+    private bool _notFound;
     private List<TechHub.Core.Models.ContentItem> videoItems = new();
     private PersistingComponentStateSubscription? _persistSubscription;
 
@@ -213,11 +218,8 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender && pageData != null)
-        {
-            await JS.InvokeVoidAsync("markScriptsLoading");
-            await JS.InvokeVoidAsync("markScriptsReady");
-        }
+        // Filtering is fully server-side Blazor; no JS init needed
+        await JS.InvokeVoidAsync("markScriptsReady");
     }
 
     protected override async Task OnInitializedAsync()
@@ -237,7 +239,8 @@
 
             if (pageData == null)
             {
-                Navigation.NavigateTo("/not-found");
+                _notFound = true;
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
                 return;
             }
 

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotGettingStarted.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotGettingStarted.razor
@@ -67,9 +67,14 @@
         </article>
     </main>
 }
+else if (_notFound)
+{
+    <NotFoundContent />
+}
 
 @code {
     private GettingStartedPageData? pageData;
+    private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
 
     private static string GenerateSectionId(string title)
@@ -100,18 +105,19 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (pageData != null)
+        try
         {
-            try
+            // Single-route page; scripts only need to init once
+            if (firstRender && pageData != null)
             {
                 await JS.InvokeVoidAsync("markScriptsLoading");
                 await JS.InvokeVoidAsync("initHighlighting");
                 await JS.InvokeVoidAsync("initTocScrollSpy");
             }
-            finally
-            {
-                await JS.InvokeVoidAsync("markScriptsReady");
-            }
+        }
+        finally
+        {
+            await JS.InvokeVoidAsync("markScriptsReady");
         }
     }
 
@@ -131,7 +137,8 @@
 
             if (pageData == null)
             {
-                Navigation.NavigateTo("/not-found");
+                _notFound = true;
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotGettingStarted.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotGettingStarted.razor
@@ -77,6 +77,9 @@ else if (_notFound)
     private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
 
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
     private static string GenerateSectionId(string title)
     {
         return title
@@ -139,6 +142,10 @@ else if (_notFound)
             {
                 _notFound = true;
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotHandbook.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotHandbook.razor
@@ -149,9 +149,14 @@
         </article>
     </main>
 }
+else if (_notFound)
+{
+    <NotFoundContent />
+}
 
 @code {
     private HandbookPageData? pageData;
+    private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
 
     /// <summary>
@@ -172,11 +177,18 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (pageData != null)
+        try
         {
-            await JS.InvokeVoidAsync("markScriptsLoading");
-            await JS.InvokeVoidAsync("initCustomPages");
-            await JS.InvokeVoidAsync("initTocScrollSpy");
+            // Single-route page; scripts only need to init once
+            if (firstRender && pageData != null)
+            {
+                await JS.InvokeVoidAsync("markScriptsLoading");
+                await JS.InvokeVoidAsync("initCustomPages");
+                await JS.InvokeVoidAsync("initTocScrollSpy");
+            }
+        }
+        finally
+        {
             await JS.InvokeVoidAsync("markScriptsReady");
         }
     }
@@ -197,7 +209,8 @@
 
             if (pageData == null)
             {
-                Navigation.NavigateTo("/not-found");
+                _notFound = true;
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotHandbook.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotHandbook.razor
@@ -159,6 +159,9 @@ else if (_notFound)
     private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
 
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
     /// <summary>
     /// Generate HTML content for TOC extraction.
     /// SidebarToc will extract headings from this HTML automatically.
@@ -211,6 +214,10 @@ else if (_notFound)
             {
                 _notFound = true;
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotLevels.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotLevels.razor
@@ -84,9 +84,14 @@
         </article>
     </main>
 }
+else if (_notFound)
+{
+    <NotFoundContent />
+}
 
 @code {
     private LevelsPageData? pageData;
+    private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
 
     /// <summary>
@@ -117,11 +122,18 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (pageData != null)
+        try
         {
-            await JS.InvokeVoidAsync("markScriptsLoading");
-            await JS.InvokeVoidAsync("initCustomPages");
-            await JS.InvokeVoidAsync("initTocScrollSpy");
+            // Single-route page; scripts only need to init once
+            if (firstRender && pageData != null)
+            {
+                await JS.InvokeVoidAsync("markScriptsLoading");
+                await JS.InvokeVoidAsync("initCustomPages");
+                await JS.InvokeVoidAsync("initTocScrollSpy");
+            }
+        }
+        finally
+        {
             await JS.InvokeVoidAsync("markScriptsReady");
         }
     }
@@ -142,7 +154,8 @@
 
             if (pageData == null)
             {
-                Navigation.NavigateTo("/not-found");
+                _notFound = true;
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotLevels.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotLevels.razor
@@ -94,6 +94,9 @@ else if (_notFound)
     private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
 
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
     /// <summary>
     /// Generate HTML content for TOC extraction.
     /// SidebarToc will extract headings from this HTML automatically.
@@ -156,6 +159,10 @@ else if (_notFound)
             {
                 _notFound = true;
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotToolTips.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotToolTips.razor
@@ -62,6 +62,9 @@ else if (_notFound)
     private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
 
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         // Static content page; no JS libraries to initialise
@@ -86,6 +89,10 @@ else if (_notFound)
             {
                 _notFound = true;
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+                if (HttpContext is not null)
+                {
+                    HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+                }
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotToolTips.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotToolTips.razor
@@ -52,18 +52,20 @@
         </article>
     </main>
 }
+else if (_notFound)
+{
+    <NotFoundContent />
+}
 
 @code {
     private ToolTipsPageData? pageData;
+    private bool _notFound;
     private PersistingComponentStateSubscription? _persistSubscription;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (pageData != null)
-        {
-            await JS.InvokeVoidAsync("markScriptsLoading");
-            await JS.InvokeVoidAsync("markScriptsReady");
-        }
+        // Static content page; no JS libraries to initialise
+        await JS.InvokeVoidAsync("markScriptsReady");
     }
 
     protected override async Task OnInitializedAsync()
@@ -82,7 +84,8 @@
 
             if (pageData == null)
             {
-                Navigation.NavigateTo("/not-found");
+                _notFound = true;
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
             }
         }
         catch (Exception ex)

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotVSCodeUpdates.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotVSCodeUpdates.razor
@@ -105,6 +105,9 @@ else
     private bool _restoredFromPersistedState;
     private bool _notFound;
 
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         try
@@ -130,6 +133,10 @@ else
         {
             _notFound = true;
             Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+            if (HttpContext is not null)
+            {
+                HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+            }
             return;
         }
 
@@ -155,6 +162,10 @@ else
         {
             _notFound = true;
             Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+            if (HttpContext is not null)
+            {
+                HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+            }
             return;
         }
 

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotVSCodeUpdates.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotVSCodeUpdates.razor
@@ -14,6 +14,13 @@
 
 <PageTitle>@GetPageTitle() - Tech Hub</PageTitle>
 
+@if (_notFound)
+{
+    <NotFoundContent />
+}
+else
+{
+
 @if (selectedVideoDetail != null)
 {
     <SeoMetaTags
@@ -83,6 +90,8 @@ else
     }
 </main>
 
+}
+
 @code {
     private const string VideoCollectionName = "vscode-updates";
 
@@ -94,22 +103,23 @@ else
     private string selectedVideoSlug = "";
     private PersistingComponentStateSubscription? _persistSubscription;
     private bool _restoredFromPersistedState;
+    private bool _notFound;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (selectedVideoDetail != null)
+        try
         {
-            try
+            if (selectedVideoDetail != null)
             {
                 await JS.InvokeVoidAsync("markScriptsLoading");
                 await JS.InvokeVoidAsync("initHighlighting");
                 await JS.InvokeVoidAsync("initMermaid");
                 await JS.InvokeVoidAsync("initTocScrollSpy");
             }
-            finally
-            {
-                await JS.InvokeVoidAsync("markScriptsReady");
-            }
+        }
+        finally
+        {
+            await JS.InvokeVoidAsync("markScriptsReady");
         }
     }
 
@@ -118,7 +128,8 @@ else
         // Validate optional slug parameter
         if (VideoSlug != null && !RouteParameterValidator.IsValidSlug(VideoSlug))
         {
-            Navigation.NavigateTo("/not-found");
+            _notFound = true;
+            Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
             return;
         }
 

--- a/src/TechHub.Web/Components/Pages/GitHubCopilotVSCodeUpdates.razor
+++ b/src/TechHub.Web/Components/Pages/GitHubCopilotVSCodeUpdates.razor
@@ -146,6 +146,18 @@ else
             return;
         }
 
+        // Reset not-found state so navigating from an invalid slug to a valid one works correctly.
+        // Blazor reuses the component instance on same-route navigation, so stale state must be cleared.
+        _notFound = false;
+
+        // Validate optional slug parameter on navigation changes too
+        if (VideoSlug != null && !RouteParameterValidator.IsValidSlug(VideoSlug))
+        {
+            _notFound = true;
+            Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found");
+            return;
+        }
+
         // When URL parameter changes, reload the selected video
         if (videoItems.Any())
         {

--- a/src/TechHub.Web/Components/Pages/Home.razor
+++ b/src/TechHub.Web/Components/Pages/Home.razor
@@ -139,10 +139,17 @@ new("Newsletter", "https://mailchi.mp/1c8d4b5ea99c/tech-hub", GetNewsletterIcon(
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (sections != null)
+        try
         {
-            await JS.InvokeVoidAsync("markScriptsLoading");
-            await JS.InvokeVoidAsync("initCustomPages");
+            // Home has expandable badges ([data-expand-target]) that only need to init once
+            if (firstRender && sections != null)
+            {
+                await JS.InvokeVoidAsync("markScriptsLoading");
+                await JS.InvokeVoidAsync("initCustomPages");
+            }
+        }
+        finally
+        {
             await JS.InvokeVoidAsync("markScriptsReady");
         }
     }

--- a/src/TechHub.Web/Components/Pages/NotFound.razor
+++ b/src/TechHub.Web/Components/Pages/NotFound.razor
@@ -1,6 +1,5 @@
 ﻿@page "/not-found"
 @layout MainLayout
-@inject NavigationManager Navigation
 @inject IJSRuntime JS
 
 <PageTitle>Not Found - Tech Hub</PageTitle>

--- a/src/TechHub.Web/Components/Pages/NotFound.razor
+++ b/src/TechHub.Web/Components/Pages/NotFound.razor
@@ -5,29 +5,11 @@
 
 <PageTitle>Not Found - Tech Hub</PageTitle>
 
-<main class="page-without-sidebar">
-    <section>
-        <p><a href="/" class="back-link">← Back to Home</a></p>
-    </section>
-</main>
+<NotFoundContent />
 
 @code {
-    [CascadingParameter]
-    private HttpContext? HttpContext { get; set; }
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await JS.InvokeVoidAsync("markScriptsReady");
-    }
-
-    protected override void OnInitialized()
-    {
-        // HttpContext is only available during prerendering (not in interactive mode).
-        // Setting the status code during prerender is sufficient — search engines and
-        // HTTP clients see the 404 status on the initial response.
-        if (HttpContext is { Response.StatusCode: 200 })
-        {
-            HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
-        }
     }
 }

--- a/src/TechHub.Web/Components/_Imports.razor
+++ b/src/TechHub.Web/Components/_Imports.razor
@@ -1,4 +1,5 @@
-﻿@using System.Net.Http
+﻿@using System.Diagnostics
+@using System.Net.Http
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing

--- a/src/TechHub.Web/Components/_Imports.razor
+++ b/src/TechHub.Web/Components/_Imports.razor
@@ -6,6 +6,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Http
 @using Microsoft.JSInterop
 @using TechHub.Web
 @using TechHub.Web.Components

--- a/src/TechHub.Web/Middleware/UrlNormalizationMiddleware.cs
+++ b/src/TechHub.Web/Middleware/UrlNormalizationMiddleware.cs
@@ -1,5 +1,4 @@
 using System.Text.RegularExpressions;
-using TechHub.Core.Models;
 using TechHub.Core.Validation;
 using TechHub.Web.Services;
 
@@ -18,7 +17,7 @@ namespace TechHub.Web.Middleware;
 ///   - Single-segment paths that are not a known section, page, or static file →
 ///     API legacy lookup to resolve the canonical /{section}/{collection}/{slug} URL.
 ///     If the API returns a result, redirect there directly (one redirect to the final URL).
-///     If not, redirect to the normalized path when the URL changed, or pass through.
+///     If not (null result or transient error after retries), return 404.
 ///
 /// Case normalization is NOT performed here. The infrastructure layer handles
 /// case-insensitive DB lookups so URLs work regardless of capitalisation.
@@ -125,49 +124,34 @@ public partial class UrlNormalizationMiddleware
         var rawSection = context.Request.Query["section"].FirstOrDefault();
         var sectionHint = RouteParameterValidator.IsValidNameSegment(rawSection) ? rawSection : null;
 
-        LegacyRedirectResult? result = null;
         try
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
             var apiClient = scope.ServiceProvider.GetRequiredService<ITechHubApiClient>();
-            result = await apiClient.GetLegacyRedirectAsync(segment, sectionHint, context.RequestAborted);
+            var result = await apiClient.GetLegacyRedirectAsync(segment, sectionHint, context.RequestAborted);
+
+            if (result != null)
+            {
+                _logger.LogInformation("Legacy slug redirect: /{Segment} -> {Url}", segment, result.Url);
+                Redirect(context, result.Url + context.Request.QueryString);
+                return;
+            }
         }
         catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
         {
             // Rethrow when the client disconnected — avoid writing a redirect onto an aborted connection.
             throw;
         }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+#pragma warning disable CA1031 // Intentional: all transient failures (timeout, HTTP error, DI issues) are treated as 404
+        catch (Exception ex)
+#pragma warning restore CA1031
         {
-            _logger.LogWarning(ex, "Legacy slug lookup failed for {Slug}; falling back to normalized path", segment);
-
-            // Graceful degradation: still clean up .html / date prefix even when API is unavailable.
-            if (pathChanged)
-            {
-                Redirect(context, normalizedPath + context.Request.QueryString);
-                return;
-            }
-
-            await _next(context);
-            return;
+            // All retries exhausted — treat the same as a null result.
+            _logger.LogWarning(ex, "Legacy slug lookup failed for {Slug} after retries", segment);
         }
 
-        if (result != null)
-        {
-            _logger.LogInformation("Legacy slug redirect: /{Segment} -> {Url}", segment, result.Url);
-            Redirect(context, result.Url + context.Request.QueryString);
-            return;
-        }
-
-        // Slug not found in DB: redirect to cleaned URL if the path changed, otherwise pass through.
-        // Passing through lets Blazor routing render /not-found.
-        if (pathChanged)
-        {
-            Redirect(context, normalizedPath + context.Request.QueryString);
-            return;
-        }
-
-        await _next(context);
+        // Slug not found (null result or API unavailable after retries): return 404 directly.
+        context.Response.StatusCode = StatusCodes.Status404NotFound;
     }
 
     /// <summary>

--- a/src/TechHub.Web/Middleware/UrlNormalizationMiddleware.cs
+++ b/src/TechHub.Web/Middleware/UrlNormalizationMiddleware.cs
@@ -136,22 +136,34 @@ public partial class UrlNormalizationMiddleware
                 Redirect(context, result.Url + context.Request.QueryString);
                 return;
             }
+
+            // Slug confirmed not in the DB — return a hard 404 so crawlers and caches treat this
+            // as a permanent absence, not a transient failure.
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
         }
         catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
         {
             // Rethrow when the client disconnected — avoid writing a redirect onto an aborted connection.
             throw;
         }
-#pragma warning disable CA1031 // Intentional: all transient failures (timeout, HTTP error, DI issues) are treated as 404
-        catch (Exception ex)
-#pragma warning restore CA1031
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            // All retries exhausted — treat the same as a null result.
-            _logger.LogWarning(ex, "Legacy slug lookup failed for {Slug} after retries", segment);
+            // Transient API failure (network error or timeout after all retries).
+            // Graceful degradation: still clean up .html / date prefix even when the API is unavailable.
+            // Do NOT return 404 here — a legitimate legacy URL would get a cacheable permanent 404
+            // just because the API was briefly down.
+            _logger.LogWarning(ex, "Legacy slug lookup failed for {Slug}; falling back to normalized path", segment);
         }
 
-        // Slug not found (null result or API unavailable after retries): return 404 directly.
-        context.Response.StatusCode = StatusCodes.Status404NotFound;
+        // API was transiently unavailable — clean up the URL if the path changed, then pass through.
+        if (pathChanged)
+        {
+            Redirect(context, normalizedPath + context.Request.QueryString);
+            return;
+        }
+
+        await _next(context);
     }
 
     /// <summary>

--- a/src/TechHub.Web/Program.cs
+++ b/src/TechHub.Web/Program.cs
@@ -244,12 +244,7 @@ builder.Services.AddHttpClient<TechHubApiClient>((sp, client) =>
             // admin POST/DELETE endpoints (processing triggers, cache invalidation, etc.).
             var method = args.Outcome.Result?.RequestMessage?.Method;
             var isIdempotent = method == HttpMethod.Get || method == HttpMethod.Head;
-            if (!isIdempotent)
-            {
-                return new ValueTask<bool>(false);
-            }
-
-            return new ValueTask<bool>(HttpClientResiliencePredicates.IsTransient(args.Outcome));
+            return new ValueTask<bool>(isIdempotent && HttpClientResiliencePredicates.IsTransient(args.Outcome));
         },
         OnRetry = args =>
         {

--- a/src/TechHub.Web/Program.cs
+++ b/src/TechHub.Web/Program.cs
@@ -219,16 +219,33 @@ builder.Services.AddHttpClient<TechHubApiClient>((sp, client) =>
 
     return handler;
 })
-.AddResilienceHandler("web-api-retry", pipeline =>
+.AddResilienceHandler("web-api-retry", (pipeline, context) =>
+{
+    var logger = context.ServiceProvider
+        .GetRequiredService<ILoggerFactory>()
+        .CreateLogger("TechHub.Web.Resilience");
+
     // 3 fast retries for transient failures (dropped connections, brief API restarts).
     // Exponential backoff: 50 → 100 → 200ms with jitter (~350ms worst case total).
+    // OnRetry logs at Debug so intermediate attempts stay out of Warning/Error channels.
+    // The final failure (after all retries) is logged at Error by TechHubApiClient.catch — exactly once.
     pipeline.AddRetry(new Microsoft.Extensions.Http.Resilience.HttpRetryStrategyOptions
     {
         MaxRetryAttempts = 3,
         Delay = TimeSpan.FromMilliseconds(50),
         BackoffType = DelayBackoffType.Exponential,
         UseJitter = true,
-    }));
+        OnRetry = args =>
+        {
+            logger.LogDebug(
+                args.Outcome.Exception,
+                "Web→API transient failure (attempt {Attempt}/3), retrying in {Delay}ms",
+                args.AttemptNumber + 1,
+                args.RetryDelay.TotalMilliseconds);
+            return ValueTask.CompletedTask;
+        },
+    });
+});
 // Register interface for dependency injection (scoped to match HttpClient lifetime)
 builder.Services.AddScoped<ITechHubApiClient>(sp => sp.GetRequiredService<TechHubApiClient>());
 
@@ -416,7 +433,7 @@ app.MapGet("/sitemap.xml", async (TechHubApiClient apiClient, CancellationToken 
 // Signs out of OIDC first (issues the end_session request to Azure AD), then
 // clears the local cookie. The OIDC sign-out redirects to "/" on completion.
 // Uses POST to prevent CSRF / prefetch-triggered logout (antiforgery validated).
-app.MapPost("/admin/logout", async context =>
+app.MapPost("/admin/logout", async (HttpContext context) =>
 {
     // OIDC sign-out must happen first — it issues the end_session_endpoint redirect.
     // Cookie sign-out is handled by the OIDC post-logout flow automatically.

--- a/src/TechHub.Web/Program.cs
+++ b/src/TechHub.Web/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
+using Polly;
 using TechHub.Core.Logging;
 using TechHub.Core.Validation;
 using TechHub.ServiceDefaults;
@@ -197,7 +198,6 @@ builder.Services.AddHttpClient<TechHubApiClient>((sp, client) =>
 {
     client.BaseAddress = new Uri(apiBaseUrl);
     // Generous timeout: some admin operations (URL processing) involve AI calls that take 30-60s.
-    // Retries/resilience belong inside the API around external dependencies, not here.
     client.Timeout = TimeSpan.FromMinutes(3);
 })
 .AddHttpMessageHandler<AdminTokenDelegatingHandler>()
@@ -218,7 +218,17 @@ builder.Services.AddHttpClient<TechHubApiClient>((sp, client) =>
     }
 
     return handler;
-});
+})
+.AddResilienceHandler("web-api-retry", pipeline =>
+    // 3 fast retries for transient failures (dropped connections, brief API restarts).
+    // Exponential backoff: 50 → 100 → 200ms with jitter (~350ms worst case total).
+    pipeline.AddRetry(new Microsoft.Extensions.Http.Resilience.HttpRetryStrategyOptions
+    {
+        MaxRetryAttempts = 3,
+        Delay = TimeSpan.FromMilliseconds(50),
+        BackoffType = DelayBackoffType.Exponential,
+        UseJitter = true,
+    }));
 // Register interface for dependency injection (scoped to match HttpClient lifetime)
 builder.Services.AddScoped<ITechHubApiClient>(sp => sp.GetRequiredService<TechHubApiClient>());
 
@@ -406,7 +416,7 @@ app.MapGet("/sitemap.xml", async (TechHubApiClient apiClient, CancellationToken 
 // Signs out of OIDC first (issues the end_session request to Azure AD), then
 // clears the local cookie. The OIDC sign-out redirects to "/" on completion.
 // Uses POST to prevent CSRF / prefetch-triggered logout (antiforgery validated).
-app.MapPost("/admin/logout", async (HttpContext context) =>
+app.MapPost("/admin/logout", async context =>
 {
     // OIDC sign-out must happen first — it issues the end_session_endpoint redirect.
     // Cookie sign-out is handled by the OIDC post-logout flow automatically.

--- a/src/TechHub.Web/Program.cs
+++ b/src/TechHub.Web/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
 using Polly;
@@ -227,6 +228,8 @@ builder.Services.AddHttpClient<TechHubApiClient>((sp, client) =>
 
     // 3 fast retries for transient failures (dropped connections, brief API restarts).
     // Exponential backoff: 50 → 100 → 200ms with jitter (~350ms worst case total).
+    // Retries are restricted to idempotent methods (GET, HEAD) to avoid replaying
+    // non-idempotent admin operations (POST, DELETE) that could cause duplicate side effects.
     // OnRetry logs at Debug so intermediate attempts stay out of Warning/Error channels.
     // The final failure (after all retries) is logged at Error by TechHubApiClient.catch — exactly once.
     pipeline.AddRetry(new Microsoft.Extensions.Http.Resilience.HttpRetryStrategyOptions
@@ -235,6 +238,19 @@ builder.Services.AddHttpClient<TechHubApiClient>((sp, client) =>
         Delay = TimeSpan.FromMilliseconds(50),
         BackoffType = DelayBackoffType.Exponential,
         UseJitter = true,
+        ShouldHandle = args =>
+        {
+            // Only retry idempotent HTTP methods to prevent duplicate side-effects on
+            // admin POST/DELETE endpoints (processing triggers, cache invalidation, etc.).
+            var method = args.Outcome.Result?.RequestMessage?.Method;
+            var isIdempotent = method == HttpMethod.Get || method == HttpMethod.Head;
+            if (!isIdempotent)
+            {
+                return new ValueTask<bool>(false);
+            }
+
+            return new ValueTask<bool>(HttpClientResiliencePredicates.IsTransient(args.Outcome));
+        },
         OnRetry = args =>
         {
             logger.LogDebug(

--- a/src/TechHub.Web/TechHub.Web.csproj
+++ b/src/TechHub.Web/TechHub.Web.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Identity.Web" />
     <PackageReference Include="Microsoft.Identity.Web.UI" />
   </ItemGroup>

--- a/src/TechHub.Web/appsettings.json
+++ b/src/TechHub.Web/appsettings.json
@@ -36,7 +36,7 @@
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.Identity": "Warning",
       "System.Net.Http.HttpClient": "Warning",
-      "Polly": "Warning"
+      "Polly": "Error"
     },
     "File": {
       "LogLevel": {

--- a/src/TechHub.Web/wwwroot/js/infinite-scroll.js
+++ b/src/TechHub.Web/wwwroot/js/infinite-scroll.js
@@ -9,9 +9,20 @@ let suppressNextTriggerCheck = false; // Anti-cascade: skip trigger check after 
 
 const TRIGGER_MARGIN_PX = 300; // Load when trigger is within 300px of viewport bottom
 
-export function observeScrollTrigger(helper, triggerElementId) {
+export function observeScrollTrigger(helper, triggerElementId, suppressOnAttach = false) {
     // Clean up previous listener if any
     dispose();
+
+    // Set the suppress flag atomically with listener attachment when restoring from
+    // circuit cache (back-navigation). This prevents a race where markScriptsReady()
+    // fires a scroll-restore event between the old separate setSuppressNextTriggerCheck()
+    // call and this observeScrollTrigger() call — a window in which handleScroll would
+    // run without suppression and could trigger a cascade of batch loads.
+    // Passing suppressOnAttach = true eliminates that two-call window: the flag is set
+    // inside this single JS execution, atomically with listener setup.
+    if (suppressOnAttach) {
+        suppressNextTriggerCheck = true;
+    }
 
     const trigger = document.getElementById(triggerElementId);
     if (!trigger) {
@@ -47,9 +58,10 @@ export function observeScrollTrigger(helper, triggerElementId) {
 
         // After scroll restoration, skip the trigger check to prevent a cascade.
         // Layout differences (fonts, images, async CSS) can place the trigger just
-        // inside the margin. The flag is set by setSuppressNextTriggerCheck and cleared
-        // here so only the first check (the immediate call in observeScrollTrigger) is
-        // skipped. Subsequent user-initiated scroll events proceed normally.
+        // inside the margin. The flag is set via suppressOnAttach (or the legacy
+        // setSuppressNextTriggerCheck) and cleared here so only the first scroll
+        // event after back-navigation is suppressed. Subsequent scroll events proceed
+        // normally.
         if (suppressNextTriggerCheck) {
             suppressNextTriggerCheck = false;
             return;
@@ -87,10 +99,10 @@ export function observeScrollTrigger(helper, triggerElementId) {
     console.debug('[InfiniteScroll] Scroll listener active for:', triggerElementId);
 
     // Check immediately in case trigger is already visible (e.g. short content).
-    // Skip when suppression is active: setSuppressNextTriggerCheck() was called for a
-    // back-navigation restore. The suppress flag must remain set to handle the first
-    // scroll event fired by markScriptsReady's window.scrollTo() — consuming it here
-    // would allow the restore scroll to trigger LoadNextBatch and cascade.
+    // Skip when suppression is active: suppressOnAttach was set for a back-navigation
+    // restore. The suppress flag must remain set to handle the first scroll event fired
+    // by markScriptsReady's window.scrollTo() — consuming it here would allow the
+    // restore scroll to trigger LoadNextBatch and cascade.
     if (!suppressNextTriggerCheck) {
         handleScroll();
     }
@@ -116,11 +128,11 @@ export function dispose() {
     // It's cleared inside handleScroll().
 }
 
-// Suppress the next trigger check in handleScroll (the immediate call inside
-// observeScrollTrigger) to prevent a cascade of batch loads on back-navigation.
-// Layout differences between the original and restored page can place the trigger
-// just inside the TRIGGER_MARGIN_PX threshold, causing runaway loading.
-// Called by ContentItemsGrid after scroll position restoration.
+// Suppress the next trigger check in handleScroll to prevent a cascade of batch
+// loads on back-navigation. Layout differences between the original and restored
+// page can place the trigger just inside the TRIGGER_MARGIN_PX threshold.
+// Prefer passing suppressOnAttach=true to observeScrollTrigger (atomic, no race).
+// This function is kept for any standalone callers that set the flag separately.
 export function setSuppressNextTriggerCheck() {
     suppressNextTriggerCheck = true;
 }

--- a/tests/TechHub.Web.Tests/Middleware/UrlNormalizationMiddlewareTests.cs
+++ b/tests/TechHub.Web.Tests/Middleware/UrlNormalizationMiddlewareTests.cs
@@ -230,8 +230,10 @@ public class UrlNormalizationMiddlewareTests
     }
 
     [Fact]
-    public async Task ApiException_Returns404()
+    public async Task ApiException_GracefulDegradation_PassesThrough()
     {
+        // /Some-Slug → API throws HttpRequestException (transient failure) →
+        // no pathChanged → pass through to Blazor routing (not a permanent 404)
         var mockApi = new Mock<ITechHubApiClient>();
         mockApi
             .Setup(x => x.GetLegacyRedirectAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
@@ -241,14 +243,15 @@ public class UrlNormalizationMiddlewareTests
 
         await middleware.InvokeAsync(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
-        nextCalled().Should().BeFalse();
+        nextCalled().Should().BeTrue("a transient API failure must not hard-404 a potentially valid legacy URL");
+        context.Response.StatusCode.Should().NotBe(StatusCodes.Status404NotFound);
     }
 
     [Fact]
-    public async Task ApiException_WithHtmlPath_Returns404()
+    public async Task ApiException_WithHtmlPath_GracefulDegradation_RedirectsToNormalizedPath()
     {
-        // .html is stripped before the API call, so the lookup is for /article — which fails.
+        // /article.html → strip .html → /article (pathChanged=true) → API throws →
+        // graceful degradation redirects to /article (still cleans up the URL)
         var mockApi = new Mock<ITechHubApiClient>();
         mockApi
             .Setup(x => x.GetLegacyRedirectAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
@@ -258,13 +261,16 @@ public class UrlNormalizationMiddlewareTests
 
         await middleware.InvokeAsync(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status301MovedPermanently,
+            "path changed (.html stripped) so we redirect to the clean URL even on API failure");
+        context.Response.Headers.Location.ToString().Should().Be("/article");
         nextCalled().Should().BeFalse();
     }
 
     [Fact]
-    public async Task ApiTimeout_WhenNotRequestAbort_Returns404()
+    public async Task ApiTimeout_WhenNotRequestAbort_GracefulDegradation_PassesThrough()
     {
+        // Timeout is a transient failure: gracefully degrade instead of hard-404ing.
         var mockApi = new Mock<ITechHubApiClient>();
         mockApi
             .Setup(x => x.GetLegacyRedirectAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
@@ -274,8 +280,8 @@ public class UrlNormalizationMiddlewareTests
 
         await middleware.InvokeAsync(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
-        nextCalled().Should().BeFalse();
+        nextCalled().Should().BeTrue("a timeout must not hard-404 a potentially valid legacy URL");
+        context.Response.StatusCode.Should().NotBe(StatusCodes.Status404NotFound);
     }
 
     [Fact]
@@ -300,9 +306,10 @@ public class UrlNormalizationMiddlewareTests
     }
 
     [Fact]
-    public async Task UnexpectedException_Returns404()
+    public async Task UnexpectedException_Propagates()
     {
-        // Any unexpected exception (DI bug, etc.) is caught and results in 404, not an unhandled crash.
+        // Non-transient exceptions (DI bugs, NullReferenceException, etc.) must propagate so
+        // they surface as 500 errors in monitoring — not silently disappear as phantom 404s.
         var mockApi = new Mock<ITechHubApiClient>();
         mockApi
             .Setup(x => x.GetLegacyRedirectAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
@@ -310,9 +317,9 @@ public class UrlNormalizationMiddlewareTests
 
         var (middleware, context, _) = CreateMiddleware(path: "/Some-Slug", mockApiClient: mockApi);
 
-        await middleware.InvokeAsync(context);
+        var act = () => middleware.InvokeAsync(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        await act.Should().ThrowAsync<InvalidOperationException>("unexpected exceptions must not be swallowed");
     }
 
     // ── Pass-through cases — no API call, no redirect ──────────────────────

--- a/tests/TechHub.Web.Tests/Middleware/UrlNormalizationMiddlewareTests.cs
+++ b/tests/TechHub.Web.Tests/Middleware/UrlNormalizationMiddlewareTests.cs
@@ -56,15 +56,14 @@ public class UrlNormalizationMiddlewareTests
     }
 
     [Fact]
-    public async Task SingleSegment_HtmlExtension_UnknownSlug_RedirectsToCleanPath()
+    public async Task SingleSegment_HtmlExtension_UnknownSlug_Returns404()
     {
-        // /article.html → strip .html → /article → API returns null → still 301 /article (URL cleaned)
+        // /article.html → strip .html → /article → API returns null → 404 directly
         var (middleware, context, nextCalled) = CreateMiddleware(path: "/article.html", apiResult: null);
 
         await middleware.InvokeAsync(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status301MovedPermanently);
-        context.Response.Headers.Location.ToString().Should().Be("/article");
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
         nextCalled().Should().BeFalse();
     }
 
@@ -116,15 +115,15 @@ public class UrlNormalizationMiddlewareTests
     }
 
     [Fact]
-    public async Task SingleSegment_DatePrefix_NotFound_RedirectsToStrippedPath()
+    public async Task SingleSegment_DatePrefix_NotFound_Returns404()
     {
-        // /2026-01-12-article → strip date → /article → API returns null → 301 /article
+        // /2026-01-12-article → strip date → /article → API returns null → 404 directly
+        // (redirecting to /article would only produce another 404, so we skip the round-trip)
         var (middleware, context, nextCalled) = CreateMiddleware(path: "/2026-01-12-article", apiResult: null);
 
         await middleware.InvokeAsync(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status301MovedPermanently);
-        context.Response.Headers.Location.ToString().Should().Be("/article");
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
         nextCalled().Should().BeFalse();
     }
 
@@ -176,14 +175,14 @@ public class UrlNormalizationMiddlewareTests
     }
 
     [Fact]
-    public async Task SingleSegment_LegacySlug_NotFound_PassesThrough()
+    public async Task SingleSegment_LegacySlug_NotFound_Returns404()
     {
         var (middleware, context, nextCalled) = CreateMiddleware(path: "/Unknown-Slug", apiResult: null);
 
         await middleware.InvokeAsync(context);
 
-        nextCalled().Should().BeTrue();
-        context.Response.StatusCode.Should().NotBe(StatusCodes.Status301MovedPermanently);
+        nextCalled().Should().BeFalse();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]
@@ -231,7 +230,7 @@ public class UrlNormalizationMiddlewareTests
     }
 
     [Fact]
-    public async Task ApiException_PassesThrough()
+    public async Task ApiException_Returns404()
     {
         var mockApi = new Mock<ITechHubApiClient>();
         mockApi
@@ -242,14 +241,14 @@ public class UrlNormalizationMiddlewareTests
 
         await middleware.InvokeAsync(context);
 
-        nextCalled().Should().BeTrue("should pass through when API throws");
-        context.Response.StatusCode.Should().NotBe(StatusCodes.Status301MovedPermanently);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        nextCalled().Should().BeFalse();
     }
 
     [Fact]
-    public async Task ApiException_WithHtmlPath_StillCleansUrl()
+    public async Task ApiException_WithHtmlPath_Returns404()
     {
-        // Even when the API is down, .html should be stripped.
+        // .html is stripped before the API call, so the lookup is for /article — which fails.
         var mockApi = new Mock<ITechHubApiClient>();
         mockApi
             .Setup(x => x.GetLegacyRedirectAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
@@ -259,15 +258,13 @@ public class UrlNormalizationMiddlewareTests
 
         await middleware.InvokeAsync(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status301MovedPermanently);
-        context.Response.Headers.Location.ToString().Should().Be("/article");
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
         nextCalled().Should().BeFalse();
     }
 
     [Fact]
-    public async Task ApiTimeout_WhenNotRequestAbort_PassesThrough()
+    public async Task ApiTimeout_WhenNotRequestAbort_Returns404()
     {
-        // TaskCanceledException from an HTTP client timeout (not a request abort) should fall through gracefully.
         var mockApi = new Mock<ITechHubApiClient>();
         mockApi
             .Setup(x => x.GetLegacyRedirectAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
@@ -277,8 +274,8 @@ public class UrlNormalizationMiddlewareTests
 
         await middleware.InvokeAsync(context);
 
-        nextCalled().Should().BeTrue("HTTP timeout (not a request abort) should fall through gracefully");
-        context.Response.StatusCode.Should().NotBe(StatusCodes.Status301MovedPermanently);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        nextCalled().Should().BeFalse();
     }
 
     [Fact]
@@ -303,9 +300,9 @@ public class UrlNormalizationMiddlewareTests
     }
 
     [Fact]
-    public async Task InvalidOperationException_Propagates()
+    public async Task UnexpectedException_Returns404()
     {
-        // InvalidOperationException indicates a DI/config bug and must not be swallowed.
+        // Any unexpected exception (DI bug, etc.) is caught and results in 404, not an unhandled crash.
         var mockApi = new Mock<ITechHubApiClient>();
         mockApi
             .Setup(x => x.GetLegacyRedirectAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
@@ -313,9 +310,9 @@ public class UrlNormalizationMiddlewareTests
 
         var (middleware, context, _) = CreateMiddleware(path: "/Some-Slug", mockApiClient: mockApi);
 
-        var act = () => middleware.InvokeAsync(context);
+        await middleware.InvokeAsync(context);
 
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     // ── Pass-through cases — no API call, no redirect ──────────────────────

--- a/tests/javascript/infinite-scroll.test.js
+++ b/tests/javascript/infinite-scroll.test.js
@@ -344,4 +344,65 @@ describe('infinite-scroll.js', () => {
             expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
         });
     });
+
+    describe('observeScrollTrigger suppressOnAttach parameter', () => {
+        it('should set suppress flag atomically when suppressOnAttach=true', () => {
+            const trigger = createTriggerElement();
+            const helper = createMockHelper();
+
+            // Trigger in viewport to test that suppression works
+            trigger.getBoundingClientRect = () => ({ top: 900 });
+
+            // Call observeScrollTrigger with suppressOnAttach=true (no separate
+            // setSuppressNextTriggerCheck call needed — eliminates the two-call race)
+            mod.observeScrollTrigger(helper, 'scroll-trigger', true);
+
+            // Immediate handleScroll is skipped because suppress flag was set atomically
+            expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
+        });
+
+        it('should suppress first scroll event after suppressOnAttach=true', () => {
+            const trigger = createTriggerElement();
+            const helper = createMockHelper();
+
+            trigger.getBoundingClientRect = () => ({ top: 900 });
+            mod.observeScrollTrigger(helper, 'scroll-trigger', true);
+            expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
+
+            // First scroll (e.g. from markScriptsReady's scroll restore): flag consumed
+            window.dispatchEvent(new Event('scroll'));
+            expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
+
+            // Second scroll: flag cleared, trigger fires normally
+            window.dispatchEvent(new Event('scroll'));
+            expect(helper.invokeMethodAsync).toHaveBeenCalledWith('LoadNextBatch');
+        });
+
+        it('should NOT suppress immediate check when suppressOnAttach=false (default)', () => {
+            const trigger = createTriggerElement();
+            const helper = createMockHelper();
+
+            // Trigger in viewport
+            trigger.getBoundingClientRect = () => ({ top: 900 });
+
+            // Default: suppressOnAttach=false — immediate handleScroll runs and loads
+            mod.observeScrollTrigger(helper, 'scroll-trigger', false);
+
+            expect(helper.invokeMethodAsync).toHaveBeenCalledWith('LoadNextBatch');
+        });
+
+        it('suppressOnAttach survives the internal dispose/re-attach cycle', () => {
+            const trigger = createTriggerElement();
+            const helper = createMockHelper();
+
+            trigger.getBoundingClientRect = () => ({ top: 900 });
+
+            // Calling dispose() alone (no previous listener) then re-attaching
+            // with suppressOnAttach=true should still suppress the immediate check
+            mod.dispose();
+            mod.observeScrollTrigger(helper, 'scroll-trigger', true);
+
+            expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/tests/javascript/infinite-scroll.test.js
+++ b/tests/javascript/infinite-scroll.test.js
@@ -361,7 +361,7 @@ describe('infinite-scroll.js', () => {
             expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
         });
 
-        it('should suppress first scroll event after suppressOnAttach=true', () => {
+        it('should consume suppress flag on first scroll event and allow subsequent scrolls', () => {
             const trigger = createTriggerElement();
             const helper = createMockHelper();
 

--- a/tests/powershell/Add-AppInsightsAnnotation.Tests.ps1
+++ b/tests/powershell/Add-AppInsightsAnnotation.Tests.ps1
@@ -1,0 +1,145 @@
+Describe "Add-AppInsightsAnnotation" {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot "../../scripts/Add-AppInsightsAnnotation.ps1"
+    }
+
+    Context "Script structure" {
+        It "Should exist as a PowerShell script" {
+            Test-Path $scriptPath | Should -BeTrue
+        }
+
+        It "Should have a valid script block" {
+            $content = Get-Content $scriptPath -Raw
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseInput($content, [ref]$null, [ref]$errors)
+            $errors.Count | Should -Be 0
+        }
+
+        It "Should set ErrorActionPreference to Stop" {
+            $content = Get-Content $scriptPath -Raw
+            $content | Should -Match '\$ErrorActionPreference\s*=\s*"Stop"'
+        }
+
+        It "Should set StrictMode" {
+            $content = Get-Content $scriptPath -Raw
+            $content | Should -Match 'Set-StrictMode\s+-Version\s+Latest'
+        }
+    }
+
+    Context "Parameters" {
+        BeforeAll {
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                $scriptPath, [ref]$null, [ref]$null
+            )
+            $paramBlock = $ast.ParamBlock
+        }
+
+        It "Should have a mandatory SubscriptionId parameter" {
+            $param = $paramBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq "SubscriptionId" }
+            $param | Should -Not -BeNullOrEmpty
+            $mandatory = $param.Attributes | Where-Object {
+                $_.TypeName.Name -eq "Parameter" -and
+                ($_.NamedArguments | Where-Object { $_.ArgumentName -eq "Mandatory" -and $_.Argument.Extent.Text -eq '$true' })
+            }
+            $mandatory | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have a mandatory ResourceGroupName parameter" {
+            $param = $paramBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq "ResourceGroupName" }
+            $param | Should -Not -BeNullOrEmpty
+            $mandatory = $param.Attributes | Where-Object {
+                $_.TypeName.Name -eq "Parameter" -and
+                ($_.NamedArguments | Where-Object { $_.ArgumentName -eq "Mandatory" -and $_.Argument.Extent.Text -eq '$true' })
+            }
+            $mandatory | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have a mandatory AppInsightsName parameter" {
+            $param = $paramBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq "AppInsightsName" }
+            $param | Should -Not -BeNullOrEmpty
+            $mandatory = $param.Attributes | Where-Object {
+                $_.TypeName.Name -eq "Parameter" -and
+                ($_.NamedArguments | Where-Object { $_.ArgumentName -eq "Mandatory" -and $_.Argument.Extent.Text -eq '$true' })
+            }
+            $mandatory | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have a mandatory AnnotationId parameter" {
+            $param = $paramBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq "AnnotationId" }
+            $param | Should -Not -BeNullOrEmpty
+            $mandatory = $param.Attributes | Where-Object {
+                $_.TypeName.Name -eq "Parameter" -and
+                ($_.NamedArguments | Where-Object { $_.ArgumentName -eq "Mandatory" -and $_.Argument.Extent.Text -eq '$true' })
+            }
+            $mandatory | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have a mandatory ReleaseName parameter" {
+            $param = $paramBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq "ReleaseName" }
+            $param | Should -Not -BeNullOrEmpty
+            $mandatory = $param.Attributes | Where-Object {
+                $_.TypeName.Name -eq "Parameter" -and
+                ($_.NamedArguments | Where-Object { $_.ArgumentName -eq "Mandatory" -and $_.Argument.Extent.Text -eq '$true' })
+            }
+            $mandatory | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have a mandatory Commit parameter" {
+            $param = $paramBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq "Commit" }
+            $param | Should -Not -BeNullOrEmpty
+            $mandatory = $param.Attributes | Where-Object {
+                $_.TypeName.Name -eq "Parameter" -and
+                ($_.NamedArguments | Where-Object { $_.ArgumentName -eq "Mandatory" -and $_.Argument.Extent.Text -eq '$true' })
+            }
+            $mandatory | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have a mandatory DeployedBy parameter" {
+            $param = $paramBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq "DeployedBy" }
+            $param | Should -Not -BeNullOrEmpty
+            $mandatory = $param.Attributes | Where-Object {
+                $_.TypeName.Name -eq "Parameter" -and
+                ($_.NamedArguments | Where-Object { $_.ArgumentName -eq "Mandatory" -and $_.Argument.Extent.Text -eq '$true' })
+            }
+            $mandatory | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have a mandatory RunUrl parameter" {
+            $param = $paramBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq "RunUrl" }
+            $param | Should -Not -BeNullOrEmpty
+            $mandatory = $param.Attributes | Where-Object {
+                $_.TypeName.Name -eq "Parameter" -and
+                ($_.NamedArguments | Where-Object { $_.ArgumentName -eq "Mandatory" -and $_.Argument.Extent.Text -eq '$true' })
+            }
+            $mandatory | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have an optional WorkspaceDirectory parameter with a default value" {
+            $param = $paramBlock.Parameters | Where-Object { $_.Name.VariablePath.UserPath -eq "WorkspaceDirectory" }
+            $param | Should -Not -BeNullOrEmpty
+            $param.DefaultValue | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context "Implementation" {
+        It "Should build the Azure management API URL with all required path components" {
+            $content = Get-Content $scriptPath -Raw
+            $content | Should -Match '\$SubscriptionId'
+            $content | Should -Match '\$ResourceGroupName'
+            $content | Should -Match '\$AppInsightsName'
+            $content | Should -Match 'management\.azure\.com'
+            $content | Should -Match 'Annotations'
+        }
+
+        It "Should include Category field in the annotation body" {
+            # The 2015-05-01 API requires a non-null Category field
+            $content = Get-Content $scriptPath -Raw
+            $content | Should -Match 'Category'
+        }
+
+        It "Should handle az rest failure via exit code check" {
+            $content = Get-Content $scriptPath -Raw
+            $content | Should -Match '\$LASTEXITCODE'
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Not-found content in this Blazor Server app always returns HTTP 200 — making these failures invisible in the App Insights Failures blade. When a user hits an invalid route or missing content item, the request was indistinguishable from a successful one in telemetry. Additionally, the URL normalization middleware had fragile fallback-redirect behavior that could mask errors, and the API HTTP client lacked retry resilience for transient failures.

## Solution

- **Not-found failure tracking**: Every not-found/invalid-content branch now calls Activity.Current?.SetStatus(ActivityStatusCode.Error, "Content not found"), making these visible in the App Insights Failures blade
- **Inline not-found rendering + real HTTP 404**: Replaced redirect-to-/not-found with an inline NotFoundContent component rendered at the original URL. The component uses [CascadingParameter] HttpContext? to set StatusCodes.Status404NotFound during SSR prerendering so crawlers and monitoring see a real 404, not a 200
- **URL middleware: graceful degradation for transient failures**: UrlNormalizationMiddleware returns hard 404 on a confirmed-null result from the API. Transient errors (HttpRequestException/TaskCanceledException) now degrade gracefully — clean up the URL if the path changed, otherwise pass through — to avoid hard-404-ing valid legacy URLs when the API is briefly down. Non-transient exceptions propagate as 500
- **HTTP retry resilience**: Added Microsoft.Extensions.Http.Resilience with 3-attempt exponential backoff (50→100→200ms with jitter) on TechHubApiClient
- **Polly logging noise silenced**: Set "Polly": "Error" in appsettings so per-retry telemetry warnings don't flood the log; an OnRetry debug callback logs attempt details for local diagnostics only
- **JS init stability**: Home.razor and ContentItem.razor use irstRender guard and 	ry/finally to prevent duplicate JS initialisation on Blazor circuit reconnect
- **CD annotation refactored**: Replaced multi-line bash in cd.yml with a reusable Add-AppInsightsAnnotation.ps1 PowerShell script

## Changes

### Web Components
- _Imports.razor — Added @using System.Diagnostics globally for all Razor components
- NotFoundContent.razor — New shared not-found component: [CascadingParameter] HttpContext? sets HTTP 404 during SSR; OnAfterRenderAsync calls markScriptsReady for layout-rendered cases; used by layout and pages
- MainLayout.razor — Inline not-found rendering + Activity.SetStatus(Error) on invalid routes
- NotFound.razor — Removed unused NavigationManager injection
- GitHubCopilotVSCodeUpdates.razor — Reset _notFound = false in OnParametersSetAsync to fix stale state on same-route navigation; added slug validation with Activity.SetStatus there too
- 10 page components — Activity.SetStatus(Error) on all not-found branches (both OnInitializedAsync and OnParametersSetAsync where applicable)
- Home.razor, ContentItem.razor — irstRender guard + 	ry/finally for JS init

### Infrastructure
- UrlNormalizationMiddleware.cs — Null result → 404; transient errors → graceful degradation; non-transient → propagate
- Program.cs — 3-attempt retry with exponential backoff via AddResilienceHandler; OnRetry debug callback
- TechHub.Web.csproj — Added Microsoft.Extensions.Http.Resilience
- ppsettings.json (API + Web) — "Polly": "Error" to suppress per-retry telemetry noise

### CI/CD
- cd.yml — Use Add-AppInsightsAnnotation.ps1 instead of inline bash
- scripts/Add-AppInsightsAnnotation.ps1 — New reusable App Insights annotation script

### Tests & Docs
- UrlNormalizationMiddlewareTests.cs — Updated 4 tests to validate graceful-degradation behavior (transient errors pass through or redirect to clean URL; non-transient exceptions propagate)
- 	ests/powershell/Add-AppInsightsAnnotation.Tests.ps1 — New Pester v5 test file with 16 tests covering script structure, all 8 mandatory parameters, and key implementation details
- docs/telemetry.md — Added Not-Found Failure Tracking section
- docs/url-routing.md — Updated to reflect graceful degradation for transient API failures
