### PR TITLE
Fix scroll cascade, rate limit, and GHC publish endpoint hardening

### DIFF
--- a/.github/prompts/address-th-review-comments.prompt.md
+++ b/.github/prompts/address-th-review-comments.prompt.md
@@ -1,6 +1,6 @@
 ---
 name: address-th-review-comments
-description: "Reviews all open review comment threads on the current branch's pull request, analyses each one, applies code fixes where needed, replies to each thread explaining what was done or why it was ignored, then commits and pushes via the pushall workflow."
+description: "Reviews all open review comment threads on the current branch's pull request, analyses each one, applies code fixes where needed, replies to each thread explaining what was done or why it was ignored, resolves each thread after replying, then commits and pushes directly."
 model: Claude Sonnet 4.6
 ---
 
@@ -187,7 +187,9 @@ Otherwise, count the unresolved threads and report:
 
 ## Step 6 — Analyse and address each open thread
 
-Work through each unresolved thread one at a time, in order.
+**🚨 CRITICAL**: Steps 6d (reply) and 6e (resolve) are **MANDATORY** for **every single thread** — including threads where you made a code fix. You are not done with a thread until you have BOTH posted a reply AND resolved it on GitHub. Never skip 6d or 6e. Never batch them for later.
+
+Work through each unresolved thread one at a time, in order. **Complete all six sub-steps before moving to the next thread.**
 
 For **each thread**, do the following:
 
@@ -199,11 +201,7 @@ Read ALL comments in the thread carefully. Understand:
 - **What is being requested** (code change, explanation, style fix, etc.)
 - **The diff hunk** for context on what the original code looked like
 
-Read the relevant section of the file being discussed to understand the current code state:
-
-```pwsh
-# Read the file to understand current code
-```
+Read the relevant section of the file being discussed to understand the current code state.
 
 ### 6b — Decide: fix or explain
 
@@ -219,11 +217,9 @@ Make the minimal correct change to address the comment. Follow the conventions i
 
 Do **not** change anything beyond what the comment requests.
 
-### 6d — Reply to the thread
+### 6d — **MANDATORY**: Reply to the thread
 
-Get the `databaseId` of the **first** comment in this thread (this is the root comment to reply to).
-
-Post a reply:
+**🚨 Do this now, before moving to 6e. Do not defer.** Get the `databaseId` of the **first** comment in this thread (this is the root comment to reply to) and post a reply immediately.
 
 **If you fixed it:**
 
@@ -237,15 +233,36 @@ gh api repos/[REPO]/pulls/[PR_NUMBER]/comments/[COMMENT_DATABASE_ID]/replies -X 
 gh api repos/[REPO]/pulls/[PR_NUMBER]/comments/[COMMENT_DATABASE_ID]/replies -X POST -f body="No change needed: [one or two sentences explaining why this comment does not require a fix — be specific and respectful]"
 ```
 
-### 6e — Checkpoint for this thread
+Verify the command exits 0. If it fails, stop and report the error.
 
-State: "✅ Thread [N/TOTAL] addressed ([FIXED/NO_FIX]). [Brief one-line summary of action taken]."
+### 6e — **MANDATORY**: Resolve the thread
+
+**🚨 Do this now, immediately after 6d. Do not defer.** Use the thread `id` (the GraphQL node ID, not the `databaseId`) to mark the thread resolved on GitHub:
+
+```pwsh
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: { threadId: "[THREAD_NODE_ID]" }) {
+    thread { isResolved }
+  }
+}'
+```
+
+Verify the response shows `"isResolved": true`. If not, stop and report the error.
+
+> **Note on dismiss vs resolve**: GitHub does not have a separate "dismiss" API for inline review threads — resolving IS the correct action. The reply you posted in 6d already makes the rationale visible. Resolving removes it from the open-discussions list so the PR stays clean.
+
+### 6f — Checkpoint for this thread
+
+Confirm both actions completed, then state:
+
+"✅ Thread [N/TOTAL] — replied and resolved. [FIXED/NO_FIX]: [Brief one-line summary of action taken]."
 
 ---
 
-Repeat steps 6a–6e for every unresolved thread before moving on.
+Repeat steps 6a–6f for every unresolved thread before moving on.
 
-**CHECKPOINT**: "✅ Step 6 completed. All [N] threads addressed. Moving to Step 7."
+**CHECKPOINT**: "✅ Step 6 completed. All [N] threads replied to and resolved on GitHub. Moving to Step 7."
 
 ---
 
@@ -275,14 +292,29 @@ Print a concise table of every thread and what was done:
 
 ---
 
-## Step 9 — Commit and push via the pushall workflow
+## Step 9 — Commit and push directly
 
-If any code changes were made in Step 6, load and follow the **pushall** skill:
+If **no code changes** were made (all threads received "no fix needed" replies), skip this step — no commit is necessary.
 
-> Read the file `.github/skills/pushall/SKILL.md` and follow the Push All Workflow from Step 1.
+Otherwise, stage and commit only the files changed in Step 6:
 
-The pushall workflow will handle staging, committing, rebasing, pushing, and updating the pull request.
+```pwsh
+git add -A
+```
 
-If **no code changes** were made (all threads received "no fix needed" replies), skip the pushall workflow — no commit is necessary.
+Write a short, direct commit message summarising the fixes (no ticket numbers, no PR references). Use imperative mood. Example: `"Address PR review comments: [brief summary]"`.
 
-**CHECKPOINT**: "✅ Step 9 completed. Workflow complete."
+```pwsh
+git commit -m "[COMMIT_MESSAGE]"
+```
+
+Pull with rebase to incorporate any upstream changes, then push:
+
+```pwsh
+git pull --rebase origin [BRANCHNAME]
+git push origin [BRANCHNAME]
+```
+
+If the push is rejected for any reason, stop and ask the user.
+
+**CHECKPOINT**: "✅ Step 9 completed. Changes committed and pushed. Workflow complete."

--- a/docs/content-processing.md
+++ b/docs/content-processing.md
@@ -131,6 +131,8 @@ The system analyzes content using `src/TechHub.Infrastructure/Data/Resources/sys
 - Sales pitches without educational value, non-English content, job postings
 - Non-development Microsoft business products (Microsoft 365 Copilot, Dynamics, Intune, etc.)
 
+> **Manual operations bypass the sales pitch rule.** Ad-hoc URL adds, transcript applications, and GHC draft publishing set `SkipSalesPitchCheck = true` on the `RawFeedItem`, which injects a `PROCESSING_OVERRIDE` line into the AI prompt instructing it to skip that exclusion. Batch RSS processing is unaffected.
+
 **Inclusion Categories**:
 
 - **AI**: Azure OpenAI, Copilot Studio, AI Foundry, Semantic Kernel, MCP

--- a/docs/scroll-system-architecture.md
+++ b/docs/scroll-system-architecture.md
@@ -21,7 +21,6 @@ and the known bugs and edge cases with their test coverage.
 - [Infinite Scroll: Normal Flow](#infinite-scroll-normal-flow)
 - [TOC Scroll-Spy: How It Ties In](#toc-scroll-spy-how-it-ties-in)
 - [The Cascade Bug](#the-cascade-bug)
-- [The Stuck Bug](#the-stuck-bug)
 - [Why requestAnimationFrame (not setTimeout)](#why-requestanimationframe-not-settimeout)
 - [Why the Circuit Cache Matters](#why-the-circuit-cache-matters)
 - [Why Not Just Disconnect the IO During Navigation?](#why-not-just-disconnect-the-io-during-navigation)
@@ -295,22 +294,38 @@ Key integration points:
 **Problem**: On back-nav, the page initially renders at scroll-Y=0. The IO trigger
 sits near the top of the (short) page. If the IO callback calls `LoadNextBatch`
 immediately, it creates a chain: batch 4 loads → trigger still visible → fires
-again → batch 5 → ... → all content loads.
+again → batch 5 → … → all content loads.
 
-**Root cause**: IO fires *during* navigation before `scrollTo(savedY)` runs.
+**Root cause**: IO fires at the restored scroll position (or at Y=0 while the
+circuit cache is still being restored) before the user has deliberately scrolled
+to request more content.
 
-**Fix**: The `navigating` flag gates the IO callback. It records
-`pendingIntersect = true` but does NOT fire. `finishNavigation()` does a manual
-`getBoundingClientRect` check at the *restored* position.
+**Fix**: `skipFirst` — when `startObserving` is called after a traverse navigation
+(either from `finishNavigation` for the deferred case, or from `observeScrollTrigger`
+when `postNavPending=true`), a `skipFirst=true` flag is passed. The IO closure keeps
+a `firstSkipped` boolean: the very first intersecting entry is silently ignored and
+the observer stays connected. Only subsequent intersection entries (triggered by
+actual user scrolling away and back) load the next batch.
 
-## The Stuck Bug
+This is strictly safer than the previous "allow 1 batch then gate" approach:
 
-**Problem**: IO is edge-triggered (fires once per state transition). If the callback
-returns early during navigation, it will never fire again for the same trigger.
+- No `postNavBatchFlushed` flag that a stray scroll event could clear before Blazor
+  re-attaches, accidentally unblocking the cascade.
+- Trade-off: if the trigger is visible on return, the user must scroll away (trigger
+  exits zone) and back (re-enters zone) before more content loads. This is acceptable
+  because in the happy path all needed content is already cached.
 
-**Fix**: `finishNavigation` checks `pendingIntersect` and flushes `LoadNextBatch`
-if the trigger is still genuinely visible. If not visible, clears the flag — the
-IO is still observing, and genuine scrolling will cause a new transition.
+**`postNavPending` race guard**: In rare cases `finishNavigation` can run *before*
+`observeScrollTrigger` is called (e.g. the JS module import takes longer than
+`markScriptsReady`'s 10 ms polling interval):
+
+- `finishNavigation` sees `infiniteScrollState?.deferred` is null → sets
+  `postNavPending = true`.
+- When `observeScrollTrigger` is later called it detects `postNavPending`, consumes
+  the flag, and calls `startObserving(skipFirst=true)`.
+
+`postNavPending` is also cleared in `beforeenhancedload` so a subsequent forward
+navigation cannot accidentally inherit the flag.
 
 ## Why requestAnimationFrame (not setTimeout)
 
@@ -341,17 +356,16 @@ at the saved scroll position.
 2. **Can't skip observing during navigation.** After `finishNavigation`, no observer
    would exist and Blazor won't re-call `observeScrollTrigger`.
 3. **Re-observing a visible element fires immediately.** IO spec delivers the first
-   intersection entry synchronously. You'd need a "skip first callback" hack.
+   intersection entry synchronously. The `skipFirst` mechanism handles this correctly.
 
 ## Known Edge Cases
 
 | Edge Case | Behavior | Covered By |
 |-----------|----------|------------|
-| Trigger visible at restored position | Loads one batch (user was at bottom) | E2E: `RestoresScrollPosition` |
-| Trigger NOT visible at restored position | Clears flag, no load | Unit: "NOT flush pendingIntersect when outside viewport+margin" |
-| IO fires at scroll-Y=0 before scrollTo | pendingIntersect deferred until after scrollTo | E2E: `DoesNotTriggerCascade` |
-| rAF timing vs IO ordering | rAF always fires AFTER IO in same frame | Unit: "call LoadNextBatch after navigation completes if trigger was intersecting during traverse" |
-| Forward nav (trigger far away) | No issue — scrollTo(0) pushes trigger off-screen | IO guard: only `'traverse'` sets pendingIntersect |
+| Trigger visible at restored position | First IO skipped, observer stays live; user must scroll away and back to load | Unit: "should NOT call LoadNextBatch on first intersection after back-nav" |
+| Trigger NOT visible at restored position | First IO fires when user scrolls to trigger → skipped; second fire loads | Unit: "should call LoadNextBatch on second intersection after back-nav" |
+| `postNavPending` race guard | finishNavigation ran before observeScrollTrigger; skipFirst applied late | Unit: "should apply skipFirst to re-attach when postNavPending is set" |
+| Forward nav (trigger far away) | No issue — scrollTo(0) pushes trigger off-screen | IO guard: only `'traverse'` sets skipFirst |
 | Trigger scrolled past (negative top) | `top < innerHeight + 300` → true → loads | Correct: past trigger means content is needed |
 | Page not tall enough for restore | ResizeObserver + MutationObserver retry (150ms debounce, 30s deadline) | Unit: scroll retry tests |
 | `beforeenhancedload` save timing | Save fires before scrollTo(0) — correct position captured | [Fixed Bug](#fixed-bug-beforeenhancedload-timing) |
@@ -367,9 +381,10 @@ at the saved scroll position.
 - `should NOT call LoadNextBatch when trigger exits intersection margin`
 - `should disconnect observer after LoadNextBatch is called (prevents cascade)`
 - `should NOT call LoadNextBatch during navigation`
-- `should call LoadNextBatch after navigation completes if trigger was intersecting during traverse`
+- `should NOT call LoadNextBatch on first intersection after back-nav (skipFirst gate)`
+- `should call LoadNextBatch on second intersection after back-nav (after first is skipped)`
+- `should apply skipFirst to re-attach when postNavPending is set (finishNavigation before observeScrollTrigger)`
 - `should create a new observer on re-attach after batch load`
-- `should NOT flush pendingIntersect when trigger is outside viewport+margin on back-nav`
 
 **Scroll position:**
 
@@ -387,7 +402,8 @@ at the saved scroll position.
 ### E2E Tests (`tests/TechHub.E2E.Tests/Web/`)
 
 - `InfiniteScrollBackNavigationTests.BackNavigation_AfterInfiniteScroll_RestoresScrollPosition` — full infinite scroll + back-nav + position check
-- `InfiniteScrollBackNavigationTests.BackNavigation_AfterInfiniteScroll_DoesNotTriggerCascade` — at most 1 extra batch on back-nav
+- `InfiniteScrollBackNavigationTests.BackNavigation_AfterInfiniteScroll_DoesNotTriggerCascade` — no cascade on back-nav
+- `InfiniteScrollBackNavigationTests.BackNavigation_CascadingLoad_ScrollDoesNotReachEnd` — scroll position stays near saved Y, page doesn't reach end
 - `ScrollRestorationTests.BackNavigation_OnLongContentPage_RestoresScrollPosition` — isolates restore on a page WITHOUT infinite scroll
 
 ### E2E Test Helpers (`tests/TechHub.E2E.Tests/Helpers/BlazorHelpers.cs`)

--- a/docs/scroll-system-architecture.md
+++ b/docs/scroll-system-architecture.md
@@ -316,13 +316,18 @@ This is strictly safer than the previous "allow 1 batch then gate" approach:
   because in the happy path all needed content is already cached.
 
 **`postNavPending` race guard**: In rare cases `finishNavigation` can run *before*
-`observeScrollTrigger` is called (e.g. the JS module import takes longer than
-`markScriptsReady`'s 10 ms polling interval):
+`observeScrollTrigger` is called (e.g. `markScriptsReady` fires before Blazor's
+`OnAfterRenderAsync`):
 
 - `finishNavigation` sees `infiniteScrollState?.deferred` is null → sets
   `postNavPending = true`.
-- When `observeScrollTrigger` is later called it detects `postNavPending`, consumes
-  the flag, and calls `startObserving(skipFirst=true)`.
+- It also immediately starts an early observer with `skipFirst=true` using
+  `lastHelper`/`lastTriggerElementId` (saved from the most recent
+  `observeScrollTrigger` call), so any user scroll during the race window is caught.
+- When `observeScrollTrigger` is later called, `dispose()` stops the early observer
+  and restarts with `skipFirst=true` (because `postNavPending` is still set).
+- If the early observer fires a real load before `observeScrollTrigger` arrives,
+  it clears `postNavPending` so the re-attach does not double-skip.
 
 `postNavPending` is also cleared in `beforeenhancedload` so a subsequent forward
 navigation cannot accidentally inherit the flag.
@@ -364,7 +369,7 @@ at the saved scroll position.
 |-----------|----------|------------|
 | Trigger visible at restored position | First IO skipped, observer stays live; user must scroll away and back to load | Unit: "should NOT call LoadNextBatch on first intersection after back-nav" |
 | Trigger NOT visible at restored position | First IO fires when user scrolls to trigger → skipped; second fire loads | Unit: "should call LoadNextBatch on second intersection after back-nav" |
-| `postNavPending` race guard | finishNavigation ran before observeScrollTrigger; skipFirst applied late | Unit: "should apply skipFirst to re-attach when postNavPending is set" |
+| `postNavPending` race guard | finishNavigation ran before observeScrollTrigger; early observer started immediately with `skipFirst=true`; `observeScrollTrigger` reconnects cleanly | Unit: "should apply skipFirst to re-attach when postNavPending is set" / "should start early observer…" |
 | Forward nav (trigger far away) | No issue — scrollTo(0) pushes trigger off-screen | IO guard: only `'traverse'` sets skipFirst |
 | Trigger scrolled past (negative top) | `top < innerHeight + 300` → true → loads | Correct: past trigger means content is needed |
 | Page not tall enough for restore | ResizeObserver + MutationObserver retry (150ms debounce, 30s deadline) | Unit: scroll retry tests |
@@ -384,6 +389,8 @@ at the saved scroll position.
 - `should NOT call LoadNextBatch on first intersection after back-nav (skipFirst gate)`
 - `should call LoadNextBatch on second intersection after back-nav (after first is skipped)`
 - `should apply skipFirst to re-attach when postNavPending is set (finishNavigation before observeScrollTrigger)`
+- `should start early observer immediately in postNavPending race if lastHelper is saved`
+- `should clear postNavPending when early observer fires real load, so re-attach does not double-skip`
 - `should create a new observer on re-attach after batch load`
 
 **Scroll position:**

--- a/scripts/Deploy-PrPreview.ps1
+++ b/scripts/Deploy-PrPreview.ps1
@@ -852,33 +852,37 @@ Write-Step "Enabling sticky sessions on Web Container App"
 # The startup probe update can leave the app in a short-lived provisioning operation.
 # Retry on ContainerAppOperationInProgress so we still enforce sticky sessions instead of
 # failing immediately on a transient Azure control-plane race.
-$stickySetDeadline = (Get-Date).AddSeconds(90)
-$stickySet = $false
+# 90s gives enough room for the prior startup-probe update to finish provisioning;
+# 5s retry cadence balances responsiveness with API throttling/noise.
+$stickySetTimeoutSeconds = 90
+$stickySetRetryDelaySeconds = 5
+$stickySetDeadline = (Get-Date).AddSeconds($stickySetTimeoutSeconds)
+$stickySessionsEnabled = $false
 while ((Get-Date) -lt $stickySetDeadline) {
     $stickySetOutput = az containerapp ingress sticky-sessions set `
         --name $webAppName `
         --resource-group $stagingRG `
         --affinity sticky 2>&1
     if ($LASTEXITCODE -eq 0) {
-        $stickySet = $true
+        $stickySessionsEnabled = $true
         break
     }
 
-    $stickySetText = ($stickySetOutput | Out-String).Trim()
-    if ($stickySetText -match 'ContainerAppOperationInProgress') {
-        Write-Warn "Container App operation still in progress while enabling sticky sessions — retrying in 5s"
-        Start-Sleep -Seconds 5
+    $stickySetOutputText = ($stickySetOutput | Out-String).Trim()
+    if ($stickySetOutputText -match 'ContainerAppOperationInProgress') {
+        Write-Warn "Container App operation still in progress while enabling sticky sessions — retrying in $($stickySetRetryDelaySeconds)s"
+        Start-Sleep -Seconds $stickySetRetryDelaySeconds
         continue
     }
 
     Write-Fail "Failed to enable sticky sessions — Blazor SignalR will not work correctly (exit code $LASTEXITCODE)"
-    if (-not [string]::IsNullOrWhiteSpace($stickySetText)) {
-        Write-Detail $stickySetText
+    if (-not [string]::IsNullOrWhiteSpace($stickySetOutputText)) {
+        Write-Detail $stickySetOutputText
     }
     exit 1
 }
-if (-not $stickySet) {
-    Write-Fail "Failed to enable sticky sessions within 90s because the Container App stayed busy"
+if (-not $stickySessionsEnabled) {
+    Write-Fail "Failed to enable sticky sessions within $($stickySetTimeoutSeconds)s because the Container App stayed busy"
     exit 1
 }
 Write-Ok "Sticky sessions set — waiting for propagation..."

--- a/scripts/Deploy-PrPreview.ps1
+++ b/scripts/Deploy-PrPreview.ps1
@@ -848,12 +848,37 @@ Set-WebStartupProbe -AppName $webAppName -ResourceGroup $stagingRG
 # than the one that rendered the SSR HTML, breaking the Blazor Server interactive circuit.
 # az containerapp create does not support --sticky-sessions, so we always set it via ingress update.
 Write-Step "Enabling sticky sessions on Web Container App"
-az containerapp ingress sticky-sessions set `
-    --name $webAppName `
-    --resource-group $stagingRG `
-    --affinity sticky
-if ($LASTEXITCODE -ne 0) {
+#
+# The startup probe update can leave the app in a short-lived provisioning operation.
+# Retry on ContainerAppOperationInProgress so we still enforce sticky sessions instead of
+# failing immediately on a transient Azure control-plane race.
+$stickySetDeadline = (Get-Date).AddSeconds(90)
+$stickySet = $false
+while ((Get-Date) -lt $stickySetDeadline) {
+    $stickySetOutput = az containerapp ingress sticky-sessions set `
+        --name $webAppName `
+        --resource-group $stagingRG `
+        --affinity sticky 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $stickySet = $true
+        break
+    }
+
+    $stickySetText = ($stickySetOutput | Out-String).Trim()
+    if ($stickySetText -match 'ContainerAppOperationInProgress') {
+        Write-Warn "Container App operation still in progress while enabling sticky sessions — retrying in 5s"
+        Start-Sleep -Seconds 5
+        continue
+    }
+
     Write-Fail "Failed to enable sticky sessions — Blazor SignalR will not work correctly (exit code $LASTEXITCODE)"
+    if (-not [string]::IsNullOrWhiteSpace($stickySetText)) {
+        Write-Detail $stickySetText
+    }
+    exit 1
+}
+if (-not $stickySet) {
+    Write-Fail "Failed to enable sticky sessions within 90s because the Container App stayed busy"
     exit 1
 }
 Write-Ok "Sticky sessions set — waiting for propagation..."

--- a/scripts/Deploy-PrPreview.ps1
+++ b/scripts/Deploy-PrPreview.ps1
@@ -196,7 +196,7 @@ function Set-WebStartupProbe {
     $patchBody | Set-Content $patchFile -Encoding utf8
 
     $apiUrl = "https://management.azure.com/subscriptions/$subId/resourceGroups/$ResourceGroup" +
-              "/providers/Microsoft.App/containerApps/$AppName?api-version=2024-03-01"
+              "/providers/Microsoft.App/containerApps/$($AppName)?api-version=2024-03-01"
     az rest --method PATCH --url $apiUrl --body "@$patchFile" --output none
 
     Remove-Item $patchFile -ErrorAction SilentlyContinue

--- a/scripts/Deploy-PrPreview.ps1
+++ b/scripts/Deploy-PrPreview.ps1
@@ -151,62 +151,62 @@ function Set-WebStartupProbe {
     #>
     param([string]$AppName, [string]$ResourceGroup)
 
-    try {
-        $webApp = az containerapp show --name $AppName --resource-group $ResourceGroup -o json 2>$null |
-            ConvertFrom-Json -ErrorAction SilentlyContinue
-        if (-not $webApp) {
-            Write-Warn "Could not retrieve Web Container App spec — startup probe not configured"
-            return
-        }
+    $webApp = az containerapp show --name $AppName --resource-group $ResourceGroup -o json 2>$null |
+        ConvertFrom-Json -ErrorAction SilentlyContinue
+    if (-not $webApp) {
+        Write-Fail "Could not retrieve Web Container App spec — cannot configure startup probe"
+        exit 1
+    }
 
-        $subId = az account show --query id -o tsv 2>$null
-        $container = $webApp.properties.template.containers[0]
+    $subId = az account show --query id -o tsv 2>$null
+    $container = $webApp.properties.template.containers[0]
 
-        # Preserve all existing non-Startup probes, then add ours.
-        $existingProbes = @()
-        if ($null -ne $container.probes) {
-            $existingProbes = @($container.probes | Where-Object { $_.type -ne 'Startup' })
-        }
+    # Preserve all existing non-Startup probes, then add ours.
+    # Use PSObject.Properties to safely check for property existence under Set-StrictMode -Version Latest:
+    # ConvertFrom-Json produces PSCustomObjects; accessing a missing property throws in strict mode.
+    $existingProbes = @()
+    if ($container.PSObject.Properties['probes'] -ne $null) {
+        $existingProbes = @($container.probes | Where-Object { $_.type -ne 'Startup' })
+    }
 
-        $startupProbe = [PSCustomObject]@{
-            type                = 'Startup'
-            httpGet             = [PSCustomObject]@{ path = '/alive'; port = 8080 }
-            initialDelaySeconds = 5
-            periodSeconds       = 20
-            failureThreshold    = 10   # ACA max is 10; 5 + 10×20 = 205s ≈ 3.4-min tolerance
-        }
+    $startupProbe = [PSCustomObject]@{
+        type                = 'Startup'
+        httpGet             = [PSCustomObject]@{ path = '/alive'; port = 8080 }
+        initialDelaySeconds = 5
+        periodSeconds       = 20
+        failureThreshold    = 10   # ACA max is 10; 5 + 10×20 = 205s ≈ 3.4-min tolerance
+    }
 
-        $container.probes = @($existingProbes) + @($startupProbe)
+    # Add-Member -Force adds the property if absent or replaces it if present —
+    # required under Set-StrictMode -Version Latest because direct assignment to a
+    # non-existent PSCustomObject property throws a PropertyNotFoundException.
+    $container | Add-Member -NotePropertyName 'probes' -NotePropertyValue (@($existingProbes) + @($startupProbe)) -Force
 
-        # ARM PATCH semantics: arrays are replaced in full, so we include the complete
-        # modified container (fetched from the live app) to preserve image/env/resources.
-        $patchBody = [PSCustomObject]@{
-            properties = [PSCustomObject]@{
-                template = [PSCustomObject]@{
-                    containers = @($container)
-                }
+    # ARM PATCH semantics: arrays are replaced in full, so we include the complete
+    # modified container (fetched from the live app) to preserve image/env/resources.
+    $patchBody = [PSCustomObject]@{
+        properties = [PSCustomObject]@{
+            template = [PSCustomObject]@{
+                containers = @($container)
             }
-        } | ConvertTo-Json -Depth 20 -Compress
-
-        $patchFile = Join-Path ([System.IO.Path]::GetTempPath()) "web-probe-patch-$AppName.json"
-        $patchBody | Set-Content $patchFile -Encoding utf8
-
-        $apiUrl = "https://management.azure.com/subscriptions/$subId/resourceGroups/$ResourceGroup" +
-                  "/providers/Microsoft.App/containerApps/$AppName?api-version=2024-03-01"
-        az rest --method PATCH --url $apiUrl --body "@$patchFile" --output none
-
-        Remove-Item $patchFile -ErrorAction SilentlyContinue
-
-        if ($LASTEXITCODE -eq 0) {
-            Write-Ok "Startup probe configured (initialDelaySeconds=5, failureThreshold=10, periodSeconds=20 → ~3.4 min tolerance)"
         }
-        else {
-            Write-Warn "Startup probe REST PATCH failed — Web may be killed if API cold-start takes >30s"
-        }
+    } | ConvertTo-Json -Depth 20 -Compress
+
+    $patchFile = Join-Path ([System.IO.Path]::GetTempPath()) "web-probe-patch-$AppName.json"
+    $patchBody | Set-Content $patchFile -Encoding utf8
+
+    $apiUrl = "https://management.azure.com/subscriptions/$subId/resourceGroups/$ResourceGroup" +
+              "/providers/Microsoft.App/containerApps/$AppName?api-version=2024-03-01"
+    az rest --method PATCH --url $apiUrl --body "@$patchFile" --output none
+
+    Remove-Item $patchFile -ErrorAction SilentlyContinue
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "Startup probe REST PATCH failed (exit code $LASTEXITCODE)"
+        exit 1
     }
-    catch {
-        Write-Warn "Startup probe configuration error: $_ — continuing"
-    }
+
+    Write-Ok "Startup probe configured (initialDelaySeconds=5, failureThreshold=10, periodSeconds=20 → ~3.4 min tolerance)"
 }
 
 function Write-ContainerAppDiagnostics {
@@ -847,17 +847,38 @@ Set-WebStartupProbe -AppName $webAppName -ResourceGroup $stagingRG
 # Without session affinity, WebSocket connections may route to a different container instance
 # than the one that rendered the SSR HTML, breaking the Blazor Server interactive circuit.
 # az containerapp create does not support --sticky-sessions, so we always set it via ingress update.
-Write-Detail "Enabling sticky sessions for $webAppName..."
+Write-Step "Enabling sticky sessions on Web Container App"
 az containerapp ingress sticky-sessions set `
     --name $webAppName `
     --resource-group $stagingRG `
     --affinity sticky
 if ($LASTEXITCODE -ne 0) {
-    Write-Warn "Could not enable sticky sessions — Blazor SignalR may be unreliable with multiple replicas"
+    Write-Fail "Failed to enable sticky sessions — Blazor SignalR will not work correctly (exit code $LASTEXITCODE)"
+    exit 1
 }
-else {
-    Write-Ok "Sticky sessions enabled (required for Blazor Server)"
+Write-Ok "Sticky sessions set — waiting for propagation..."
+
+# Poll until the ingress affinity is confirmed as 'sticky'. The az CLI call returns quickly
+# but the setting may not yet be reflected in the resource — give it up to 60 seconds.
+$stickyDeadline = (Get-Date).AddSeconds(60)
+$stickyConfirmed = $false
+while ((Get-Date) -lt $stickyDeadline) {
+    $affinity = az containerapp show `
+        --name $webAppName `
+        --resource-group $stagingRG `
+        --query "properties.configuration.ingress.stickySessions.affinity" `
+        -o tsv 2>$null
+    if ($affinity -eq 'sticky') {
+        $stickyConfirmed = $true
+        break
+    }
+    Start-Sleep -Seconds 5
 }
+if (-not $stickyConfirmed) {
+    Write-Fail "Sticky sessions did not propagate within 60s — Blazor SignalR will not work correctly"
+    exit 1
+}
+Write-Ok "Sticky sessions confirmed active (affinity=sticky)"
 
 # Get the actual web FQDN
 $webFqdn = az containerapp show `

--- a/src/TechHub.Api/Endpoints/AdminEndpoints.cs
+++ b/src/TechHub.Api/Endpoints/AdminEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using TechHub.Api.Services;
+using TechHub.Core;
 using TechHub.Core.Configuration;
 using TechHub.Core.Interfaces;
 using TechHub.Core.Logging;
@@ -715,7 +716,8 @@ public static partial class AdminEndpoints
             CollectionName = collection,
             FeedLevelAuthor = existing.Author,
             FeedTags = existing.Tags.ToList(),
-            FullContent = request.Transcript.Trim()
+            FullContent = request.Transcript.Trim(),
+            SkipSalesPitchCheck = true
         };
 
         CategorizationResult categorizationResult;
@@ -977,6 +979,35 @@ public static partial class AdminEndpoints
 
     // ── GHC feature plans handlers ───────────────────────────────────────────
 
+    /// <summary>
+    /// Extracts the value of a single query-string parameter by name.
+    /// Returns null if the key is absent or has no value.
+    /// </summary>
+    private static string? ExtractQueryParam(string query, string key)
+    {
+        // query is in the form "?k1=v1&k2=v2" (or empty)
+        var span = query.AsSpan().TrimStart('?');
+        foreach (var part in span.Split('&'))
+        {
+            var token = span[part];
+            var eq = token.IndexOf('=');
+
+            if (eq < 0)
+            {
+                continue;
+            }
+
+            var k = token[..eq];
+
+            if (k.Equals(key, StringComparison.OrdinalIgnoreCase))
+            {
+                return new string(token[(eq + 1)..]);
+            }
+        }
+
+        return null;
+    }
+
     private static readonly HashSet<string> _validPlanNames =
         new(["Free", "Student", "Pro", "Business", "Pro+", "Enterprise"], StringComparer.OrdinalIgnoreCase);
 
@@ -1056,15 +1087,35 @@ public static partial class AdminEndpoints
         }
 
         // Validate that the URL points to a video (not a channel, playlist, etc.)
-        // Supported: watch?v=..., youtu.be/<id>, /shorts/<id>, /embed/<id>
+        // Supported: watch?v=<id>, youtu.be/<id>, /shorts/<id>, /embed/<id>
         var path = uri.AbsolutePath;
-        var isVideoUrl = host is "youtu.be"
-            ? path.Length > 1  // e.g. /dQw4w9WgXcQ
-            : path.StartsWith("/shorts/", StringComparison.OrdinalIgnoreCase)
-              || path.StartsWith("/embed/", StringComparison.OrdinalIgnoreCase)
-              || (path.Equals("/watch", StringComparison.OrdinalIgnoreCase)
-                  && (uri.Query.StartsWith("?v=", StringComparison.Ordinal)
-                      || uri.Query.Contains("&v=", StringComparison.Ordinal)));
+        bool isVideoUrl;
+        if (host is "youtu.be")
+        {
+            // Must have exactly one non-empty path segment (e.g. /dQw4w9WgXcQ) with no
+            // extra segments. Playlists (/playlist), channels, and other paths are rejected.
+            var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            isVideoUrl = segments.Length == 1 && segments[0].Length > 0;
+        }
+        else if (path.StartsWith("/shorts/", StringComparison.OrdinalIgnoreCase))
+        {
+            // Require a non-empty ID segment after /shorts/ (e.g. /shorts/dQw4w9WgXcQ)
+            var id = path["/shorts/".Length..];
+            isVideoUrl = id.Length > 0 && !id.Contains('/', StringComparison.Ordinal);
+        }
+        else if (path.StartsWith("/embed/", StringComparison.OrdinalIgnoreCase))
+        {
+            // Require a non-empty ID segment after /embed/ (e.g. /embed/dQw4w9WgXcQ)
+            var id = path["/embed/".Length..];
+            isVideoUrl = id.Length > 0 && !id.Contains('/', StringComparison.Ordinal);
+        }
+        else
+        {
+            // /watch?v=<id> — ensure ?v= is present and has a non-empty value
+            isVideoUrl = path.Equals("/watch", StringComparison.OrdinalIgnoreCase)
+                && ExtractQueryParam(uri.Query, "v") is { Length: > 0 };
+        }
+
         if (!isVideoUrl)
         {
             return Results.BadRequest("The URL must be a YouTube video URL (e.g., https://youtu.be/... or https://www.youtube.com/watch?v=...).");
@@ -1115,7 +1166,8 @@ public static partial class AdminEndpoints
             CollectionName = "videos",
             FeedLevelAuthor = existing.Author,
             FeedTags = existing.Tags.ToList(),
-            FullContent = transcript
+            FullContent = transcript,
+            SkipSalesPitchCheck = true
         };
 
         CategorizationResult categorizationResult;
@@ -1198,7 +1250,7 @@ public static partial class AdminEndpoints
                 hasTranscript: transcript is not null,
                 ct);
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("already owned", StringComparison.Ordinal))
+        catch (ProcessedUrlConflictException)
         {
             return Results.Conflict(new
             {

--- a/src/TechHub.Api/Endpoints/AdminEndpoints.cs
+++ b/src/TechHub.Api/Endpoints/AdminEndpoints.cs
@@ -1055,6 +1055,21 @@ public static partial class AdminEndpoints
             return Results.BadRequest("The URL must be a YouTube video URL.");
         }
 
+        // Validate that the URL points to a video (not a channel, playlist, etc.)
+        // Supported: watch?v=..., youtu.be/<id>, /shorts/<id>, /embed/<id>
+        var path = uri.AbsolutePath;
+        var isVideoUrl = host is "youtu.be"
+            ? path.Length > 1  // e.g. /dQw4w9WgXcQ
+            : path.StartsWith("/shorts/", StringComparison.OrdinalIgnoreCase)
+              || path.StartsWith("/embed/", StringComparison.OrdinalIgnoreCase)
+              || (path.Equals("/watch", StringComparison.OrdinalIgnoreCase)
+                  && (uri.Query.StartsWith("?v=", StringComparison.Ordinal)
+                      || uri.Query.Contains("&v=", StringComparison.Ordinal)));
+        if (!isVideoUrl)
+        {
+            return Results.BadRequest("The URL must be a YouTube video URL (e.g., https://youtu.be/... or https://www.youtube.com/watch?v=...).");
+        }
+
         if (request.Plans is null || request.Plans.Count == 0)
         {
             return Results.BadRequest("At least one plan is required.");
@@ -1170,15 +1185,26 @@ public static partial class AdminEndpoints
             ExternalUrl = youtubeUrl
         };
 
-        var updated = await contentRepo.PublishGhcFeatureDraftAsync(
-            slug,
-            existing.ExternalUrl ?? string.Empty,
-            youtubeUrl,
-            updatedEditData,
-            request.Plans,
-            request.GhesSupport,
-            hasTranscript: transcript is not null,
-            ct);
+        bool updated;
+        try
+        {
+            updated = await contentRepo.PublishGhcFeatureDraftAsync(
+                slug,
+                existing.ExternalUrl ?? string.Empty,
+                youtubeUrl,
+                updatedEditData,
+                request.Plans,
+                request.GhesSupport,
+                hasTranscript: transcript is not null,
+                ct);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("already owned", StringComparison.Ordinal))
+        {
+            return Results.Conflict(new
+            {
+                message = "This YouTube URL is already used by another content item. Delete this draft manually and use the existing item instead."
+            });
+        }
 
         if (!updated)
         {

--- a/src/TechHub.Api/Program.cs
+++ b/src/TechHub.Api/Program.cs
@@ -315,7 +315,11 @@ builder.Services.AddAuthorization(options =>
 // Rate limiting: defense-in-depth for the API (primary rate limiting is on the Web layer)
 // Disabled in IntegrationTest environment to avoid throttling test suites that run many
 // requests from a single IP within a short window.
+// Loopback exemptions are scoped to Development/IntegrationTest so that a spoofed
+// X-Forwarded-For: 127.0.0.1 cannot bypass rate limiting in production
+// (UseForwardedHeaders runs before UseRateLimiter).
 var isIntegrationTest = builder.Environment.IsEnvironment("IntegrationTest");
+var isLoopbackExempt = builder.Environment.IsDevelopment() || isIntegrationTest;
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
@@ -333,7 +337,9 @@ builder.Services.AddRateLimiter(options =>
 
     // Public content endpoints: generous limit (defense against runaway loops or future architecture changes).
     // Loopback connections (localhost) are exempt — they are always local dev or CI integration test
-    // runners, not external clients. RemoteIpAddress is the socket-level TCP IP and cannot be spoofed.
+    // runners, not external clients. Loopback exemption is restricted to Development and
+    // IntegrationTest: UseForwardedHeaders rewrites RemoteIpAddress before UseRateLimiter
+    // runs, so a spoofed X-Forwarded-For: 127.0.0.1 could otherwise bypass rate limiting.
     options.AddPolicy("api-public", context =>
     {
         if (isIntegrationTest)
@@ -342,7 +348,7 @@ builder.Services.AddRateLimiter(options =>
         }
 
         var ip = context.Connection.RemoteIpAddress;
-        if (ip != null && IPAddress.IsLoopback(ip))
+        if (isLoopbackExempt && ip != null && IPAddress.IsLoopback(ip))
         {
             return RateLimitPartition.GetNoLimiter("loopback");
         }
@@ -361,7 +367,7 @@ builder.Services.AddRateLimiter(options =>
 
     // Admin endpoints: per-user limit for authenticated requests (generous for legitimate admin
     // work), strict IP-based limit for unauthenticated requests (brute-force protection).
-    // Loopback connections are exempt for the same reason as api-public.
+    // Loopback exemption is restricted to Development/IntegrationTest for the same reason as api-public.
     // NOTE: UseRateLimiter() must run after UseAuthentication() so context.User is populated.
     options.AddPolicy("api-admin", context =>
     {
@@ -371,7 +377,7 @@ builder.Services.AddRateLimiter(options =>
         }
 
         var ip = context.Connection.RemoteIpAddress;
-        if (ip != null && IPAddress.IsLoopback(ip))
+        if (isLoopbackExempt && ip != null && IPAddress.IsLoopback(ip))
         {
             return RateLimitPartition.GetNoLimiter("loopback");
         }

--- a/src/TechHub.Api/Program.cs
+++ b/src/TechHub.Api/Program.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Net;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -330,29 +331,49 @@ builder.Services.AddRateLimiter(options =>
         await context.HttpContext.Response.WriteAsync("Rate limit exceeded. Please retry later.", token);
     };
 
-    // Public content endpoints: generous limit (defense against runaway loops or future architecture changes)
+    // Public content endpoints: generous limit (defense against runaway loops or future architecture changes).
+    // Loopback connections (localhost) are exempt — they are always local dev or CI integration test
+    // runners, not external clients. RemoteIpAddress is the socket-level TCP IP and cannot be spoofed.
     options.AddPolicy("api-public", context =>
-        isIntegrationTest
-            ? RateLimitPartition.GetNoLimiter("no-limit")
-            : RateLimitPartition.GetSlidingWindowLimiter(
-                partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
-                factory: _ => new SlidingWindowRateLimiterOptions
-                {
-                    PermitLimit = 200,
-                    Window = TimeSpan.FromMinutes(1),
-                    SegmentsPerWindow = 6,
-                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-                    QueueLimit = 10
-                }));
+    {
+        if (isIntegrationTest)
+        {
+            return RateLimitPartition.GetNoLimiter("no-limit");
+        }
+
+        var ip = context.Connection.RemoteIpAddress;
+        if (ip != null && IPAddress.IsLoopback(ip))
+        {
+            return RateLimitPartition.GetNoLimiter("loopback");
+        }
+
+        return RateLimitPartition.GetSlidingWindowLimiter(
+            partitionKey: ip?.ToString() ?? "unknown",
+            factory: _ => new SlidingWindowRateLimiterOptions
+            {
+                PermitLimit = 200,
+                Window = TimeSpan.FromMinutes(1),
+                SegmentsPerWindow = 6,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 10
+            });
+    });
 
     // Admin endpoints: per-user limit for authenticated requests (generous for legitimate admin
     // work), strict IP-based limit for unauthenticated requests (brute-force protection).
+    // Loopback connections are exempt for the same reason as api-public.
     // NOTE: UseRateLimiter() must run after UseAuthentication() so context.User is populated.
     options.AddPolicy("api-admin", context =>
     {
         if (isIntegrationTest)
         {
             return RateLimitPartition.GetNoLimiter("no-limit");
+        }
+
+        var ip = context.Connection.RemoteIpAddress;
+        if (ip != null && IPAddress.IsLoopback(ip))
+        {
+            return RateLimitPartition.GetNoLimiter("loopback");
         }
 
         // Prefer the Azure AD object-ID claim so each admin user gets their own bucket.
@@ -377,7 +398,7 @@ builder.Services.AddRateLimiter(options =>
 
         // Unauthenticated — keep a strict IP limit to deter auth brute-forcing.
         return RateLimitPartition.GetSlidingWindowLimiter(
-            partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            partitionKey: ip?.ToString() ?? "unknown",
             factory: _ => new SlidingWindowRateLimiterOptions
             {
                 PermitLimit = 30,

--- a/src/TechHub.Core/Models/ContentProcessing/RawFeedItem.cs
+++ b/src/TechHub.Core/Models/ContentProcessing/RawFeedItem.cs
@@ -51,4 +51,12 @@ public sealed class RawFeedItem
     /// <summary>Whether this item links to a YouTube video.</summary>
     public bool IsYouTube => ExternalUrl.Contains("youtube.com", StringComparison.OrdinalIgnoreCase)
         || ExternalUrl.Contains("youtu.be", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// When <c>true</c>, instructs the AI to skip the "Sales Pitches" exclusion rule for this item
+    /// and categorize it normally regardless of promotional content.
+    /// Set for manual operations (ad-hoc adds, transcript application, GHC draft publishing)
+    /// where an operator has already decided the content belongs.
+    /// </summary>
+    public bool SkipSalesPitchCheck { get; init; }
 }

--- a/src/TechHub.Core/ProcessedUrlConflictException.cs
+++ b/src/TechHub.Core/ProcessedUrlConflictException.cs
@@ -1,0 +1,23 @@
+namespace TechHub.Core;
+
+/// <summary>
+/// Thrown when an operation attempts to use a YouTube URL that is already owned by
+/// a different content item in the processed_urls table.
+/// </summary>
+public sealed class ProcessedUrlConflictException : Exception
+{
+    public ProcessedUrlConflictException()
+        : base("The YouTube URL is already owned by another content item in processed_urls.")
+    {
+    }
+
+    public ProcessedUrlConflictException(string message)
+        : base(message)
+    {
+    }
+
+    public ProcessedUrlConflictException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/TechHub.Infrastructure/Repositories/ContentRepository.cs
+++ b/src/TechHub.Infrastructure/Repositories/ContentRepository.cs
@@ -6,6 +6,7 @@ using Dapper;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using TechHub.Core;
 using TechHub.Core.Configuration;
 using TechHub.Core.Interfaces;
 using TechHub.Core.Models;
@@ -1979,8 +1980,7 @@ WHERE slug = @Slug
                 // content_items.external_url pointing at a URL owned by another item.
                 if (upsertRows == 0)
                 {
-                    transaction.Rollback();
-                    throw new InvalidOperationException("The YouTube URL is already owned by another content item in processed_urls.");
+                    throw new ProcessedUrlConflictException();
                 }
             }
 

--- a/src/TechHub.Infrastructure/Repositories/ContentRepository.cs
+++ b/src/TechHub.Infrastructure/Repositories/ContentRepository.cs
@@ -1875,7 +1875,8 @@ SET title                = @Title,
     updated_at           = NOW()
 WHERE slug = @Slug
   AND collection_name = 'videos'
-  AND subcollection_name = 'ghc-features'";
+  AND subcollection_name = 'ghc-features'
+  AND draft = true";
 
         var parameters = new
         {
@@ -1957,7 +1958,7 @@ WHERE slug = @Slug
                         transaction: transaction,
                         cancellationToken: ct));
 
-                await Connection.ExecuteAsync(
+                var upsertRows = await Connection.ExecuteAsync(
                     new CommandDefinition(
                         @"INSERT INTO processed_urls (external_url, status, feed_name, collection_name, has_transcript, slug)
                           VALUES (@NewExternalUrl, 'succeeded', @FeedName, @CollectionName, @HasTranscript, @Slug)
@@ -1972,6 +1973,15 @@ WHERE slug = @Slug
                         new { NewExternalUrl = newExternalUrl, FeedName = editData.FeedName, CollectionName = "videos", HasTranscript = hasTranscript, Slug = slug },
                         transaction: transaction,
                         cancellationToken: ct));
+
+                // 0 rows means external_url already exists for a different slug — the
+                // WHERE condition on the DO UPDATE clause did not match. Rollback to prevent
+                // content_items.external_url pointing at a URL owned by another item.
+                if (upsertRows == 0)
+                {
+                    transaction.Rollback();
+                    throw new InvalidOperationException("The YouTube URL is already owned by another content item in processed_urls.");
+                }
             }
 
             transaction.Commit();

--- a/src/TechHub.Infrastructure/Services/ContentProcessing/AiCategorizationService.cs
+++ b/src/TechHub.Infrastructure/Services/ContentProcessing/AiCategorizationService.cs
@@ -368,6 +368,13 @@ public sealed class AiCategorizationService : IAiCategorizationService
         var sb = new StringBuilder();
         sb.AppendLine(CultureInfo.InvariantCulture, $"Please categorize the following content:");
         sb.AppendLine();
+
+        if (item.SkipSalesPitchCheck)
+        {
+            sb.AppendLine("PROCESSING_OVERRIDE: SkipSalesPitchCheck=true — Do not apply the \"Sales Pitches\" generic exclusion rule for this item. If the content qualifies on any other grounds, categorize it normally.");
+            sb.AppendLine();
+        }
+
         sb.AppendLine(CultureInfo.InvariantCulture, $"FEED: {item.FeedName}");
         sb.AppendLine(CultureInfo.InvariantCulture, $"COLLECTION: {item.CollectionName}");
         sb.AppendLine(CultureInfo.InvariantCulture, $"URL: {item.ExternalUrl}");

--- a/src/TechHub.Infrastructure/Services/ContentProcessing/ArticleContentService.cs
+++ b/src/TechHub.Infrastructure/Services/ContentProcessing/ArticleContentService.cs
@@ -70,7 +70,8 @@ public sealed partial class ArticleContentService : IArticleContentService
                 FeedTags = item.FeedTags,
                 FeedName = item.FeedName,
                 CollectionName = item.CollectionName,
-                FullContent = mainContent
+                FullContent = mainContent,
+                SkipSalesPitchCheck = item.SkipSalesPitchCheck
             };
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/TechHub.Infrastructure/Services/ContentProcessing/ContentProcessingService.cs
+++ b/src/TechHub.Infrastructure/Services/ContentProcessing/ContentProcessingService.cs
@@ -392,7 +392,8 @@ public sealed class ContentProcessingService
                 PublishedAt = _timeProvider.GetUtcNow(),
                 FeedName = feedName,
                 CollectionName = collectionName,
-                FeedItemData = feedItemData
+                FeedItemData = feedItemData,
+                SkipSalesPitchCheck = true
             };
 
             // Shared per-item pipeline: tags → content → AI → write
@@ -519,7 +520,8 @@ public sealed class ContentProcessingService
                         FeedTags = mergedTags,
                         FeedName = raw.FeedName,
                         CollectionName = raw.CollectionName,
-                        FullContent = raw.FullContent
+                        FullContent = raw.FullContent,
+                        SkipSalesPitchCheck = raw.SkipSalesPitchCheck
                     };
                 }
             }
@@ -551,7 +553,8 @@ public sealed class ContentProcessingService
                     FeedTags = raw.FeedTags,
                     FeedName = raw.FeedName,
                     CollectionName = raw.CollectionName,
-                    FullContent = manualTranscript
+                    FullContent = manualTranscript,
+                    SkipSalesPitchCheck = raw.SkipSalesPitchCheck
                 };
                 hasTranscript = true;
                 transcriptStatus = "manual transcript";

--- a/src/TechHub.Web/Components/Pages/Admin/AdminCopilotFeatures.razor
+++ b/src/TechHub.Web/Components/Pages/Admin/AdminCopilotFeatures.razor
@@ -167,7 +167,7 @@
                 {
                     <div class="features-publish-section">
                         <p class="features-publish-heading">Publish from YouTube</p>
-                        <p class="features-publish-hint">Enter the YouTube URL and optionally paste a transcript. The AI will regenerate all content fields and update this item in-place — the slug and URL are preserved.</p>
+                        <p class="features-publish-hint">Enter the YouTube URL and optionally paste a transcript. The AI will regenerate all content fields and update this item in-place — the slug is preserved while the external URL is replaced with the real YouTube URL.</p>
                         <input type="url"
                                class="admin-input features-publish-input"
                                placeholder="https://youtu.be/..."

--- a/src/TechHub.Web/Program.cs
+++ b/src/TechHub.Web/Program.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authentication;
@@ -288,29 +289,48 @@ builder.Services.AddRateLimiter(options =>
         await context.HttpContext.Response.WriteAsync("Rate limit exceeded. Please retry later.", token);
     };
 
-    // General page requests: 60/min per IP (covers Blazor Server HTML and enhanced navigation)
+    // General page requests: 60/min per IP (covers Blazor Server HTML and enhanced navigation).
+    // Loopback connections (localhost) are exempt — they are always local dev or E2E test runners,
+    // not external clients. RemoteIpAddress is the socket-level TCP IP and cannot be spoofed.
     options.AddPolicy("web-general", context =>
-        RateLimitPartition.GetFixedWindowLimiter(
-            partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+    {
+        var ip = context.Connection.RemoteIpAddress;
+        if (ip != null && IPAddress.IsLoopback(ip))
+        {
+            return RateLimitPartition.GetNoLimiter("loopback");
+        }
+
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: ip?.ToString() ?? "unknown",
             factory: _ => new FixedWindowRateLimiterOptions
             {
                 PermitLimit = 60,
                 Window = TimeSpan.FromMinutes(1),
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 5
-            }));
+            });
+    });
 
-    // RSS feed endpoints: stricter limit — bot-targeted content syndication
+    // RSS feed endpoints: stricter limit — bot-targeted content syndication.
+    // Loopback connections are exempt for the same reason as web-general.
     options.AddPolicy("web-rss", context =>
-        RateLimitPartition.GetFixedWindowLimiter(
-            partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+    {
+        var ip = context.Connection.RemoteIpAddress;
+        if (ip != null && IPAddress.IsLoopback(ip))
+        {
+            return RateLimitPartition.GetNoLimiter("loopback");
+        }
+
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: ip?.ToString() ?? "unknown",
             factory: _ => new FixedWindowRateLimiterOptions
             {
                 PermitLimit = 20,
                 Window = TimeSpan.FromMinutes(1),
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 0
-            }));
+            });
+    });
     // Note: Blazor Server SignalR circuits (/_blazor) cannot be rate-limited via endpoint
     // metadata because they go through the Blazor hub middleware, not endpoint routing.
     // SignalR concurrency is instead managed by the SignalR MaximumParallelInvocationsPerClient

--- a/src/TechHub.Web/Program.cs
+++ b/src/TechHub.Web/Program.cs
@@ -274,6 +274,9 @@ builder.Services.AddHttpClient<TechHubApiClient>((sp, client) =>
 builder.Services.AddScoped<ITechHubApiClient>(sp => sp.GetRequiredService<TechHubApiClient>());
 
 // Rate limiting: protect the public Web surface against excessive requests and bot scraping
+// Loopback exemptions are scoped to Development so that a spoofed X-Forwarded-For: 127.0.0.1
+// cannot bypass rate limiting in production (UseForwardedHeaders runs before UseRateLimiter).
+var isLoopbackExempt = builder.Environment.IsDevelopment();
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
@@ -290,12 +293,13 @@ builder.Services.AddRateLimiter(options =>
     };
 
     // General page requests: 60/min per IP (covers Blazor Server HTML and enhanced navigation).
-    // Loopback connections (localhost) are exempt — they are always local dev or E2E test runners,
-    // not external clients. RemoteIpAddress is the socket-level TCP IP and cannot be spoofed.
+    // Loopback exemption is restricted to Development: UseForwardedHeaders rewrites RemoteIpAddress
+    // before UseRateLimiter runs, so a spoofed X-Forwarded-For: 127.0.0.1 could otherwise bypass
+    // rate limiting in production.
     options.AddPolicy("web-general", context =>
     {
         var ip = context.Connection.RemoteIpAddress;
-        if (ip != null && IPAddress.IsLoopback(ip))
+        if (isLoopbackExempt && ip != null && IPAddress.IsLoopback(ip))
         {
             return RateLimitPartition.GetNoLimiter("loopback");
         }
@@ -312,11 +316,11 @@ builder.Services.AddRateLimiter(options =>
     });
 
     // RSS feed endpoints: stricter limit — bot-targeted content syndication.
-    // Loopback connections are exempt for the same reason as web-general.
+    // Loopback exemption is restricted to Development for the same reason as web-general.
     options.AddPolicy("web-rss", context =>
     {
         var ip = context.Connection.RemoteIpAddress;
-        if (ip != null && IPAddress.IsLoopback(ip))
+        if (isLoopbackExempt && ip != null && IPAddress.IsLoopback(ip))
         {
             return RateLimitPartition.GetNoLimiter("loopback");
         }

--- a/src/TechHub.Web/wwwroot/js/scroll-manager.js
+++ b/src/TechHub.Web/wwwroot/js/scroll-manager.js
@@ -43,10 +43,10 @@ window.__savedScrollPositions = savedPositions; // exposed for tests
 // RAF throttle flag for TOC updates during scroll (one update per frame).
 let tocRafPending = false;
 
-// Set after finishNavigation flushes a single batch. Blocks subsequent IO callbacks
-// until the user genuinely scrolls, preventing the cascade bug where rapid
-// re-observe cycles load all remaining content. Cleared in onScroll.
-let postNavBatchFlushed = false;
+// Set when a traverse (back/forward) navigation completes but observeScrollTrigger
+// hasn't been called yet (race: finishNavigation ran before Blazor called observeScrollTrigger).
+// Cleared once observeScrollTrigger consumes it and starts the observer with skipFirst=true.
+let postNavPending = false;
 
 // ============================================================================
 // Keyboard Navigation Detection
@@ -292,11 +292,13 @@ window.__restoreScrollPosition = restoreScrollPosition;
  * @see docs/scroll-system-architecture.md
  */
 function finishNavigation() {
+    const wasTraverse = navigating === 'traverse';
     navigating = false;
     // If observeScrollTrigger was called during navigation, it deferred actual observation.
     // Now that scroll is restored, start the IO at the real viewport position.
-    // If the trigger is in range, IO fires in the next frame (1 allowed batch).
-    // startObserving sets postNavBatchFlushed after that first fire so re-attaches are blocked.
+    // skipFirst=true: ignore the first intersection so the browser's position after
+    // scroll restore doesn't trigger an automatic batch load — the user must scroll
+    // deliberately. See docs/scroll-system-architecture.md#the-cascade-bug.
     if (infiniteScrollState?.deferred) {
         const { helper, triggerElementId } = infiniteScrollState;
         const trigger = document.getElementById(triggerElementId);
@@ -305,6 +307,11 @@ function finishNavigation() {
         } else {
             infiniteScrollState = null;
         }
+    } else if (wasTraverse) {
+        // observeScrollTrigger hasn't been called yet (race: markScriptsReady fired before
+        // Blazor's OnAfterRenderAsync). Flag it so the next observeScrollTrigger call
+        // uses skipFirst=true.
+        postNavPending = true;
     }
     // Run scroll-end work once at the final position (TOC highlight, etc.)
     onScrollEnd();
@@ -465,6 +472,9 @@ function setupBlazorListeners() {
             navigating = 'forward';
             window.__scriptsReady = false;
             showNavSpinner();
+            // A stale postNavPending from a previous traverse nav must not bleed into
+            // a forward nav cycle where skipFirst protection is not needed.
+            postNavPending = false;
         });
 
         Blazor.addEventListener('enhancedload', () => {
@@ -813,6 +823,11 @@ export function observeScrollTrigger(helper, triggerElementId) {
     if (navigating) {
         // Defer — finishNavigation() will start observing at the restored scroll position.
         infiniteScrollState = { helper, triggerElementId, observer: null, deferred: true };
+    } else if (postNavPending) {
+        // finishNavigation already ran (traverse nav) but observeScrollTrigger wasn't called
+        // yet at that time. Apply skipFirst protection now.
+        postNavPending = false;
+        startObserving(helper, triggerElementId, trigger, true);
     } else {
         startObserving(helper, triggerElementId, trigger);
     }
@@ -830,24 +845,30 @@ export function observeScrollTrigger(helper, triggerElementId) {
 /**
  * Create and start the IntersectionObserver for the scroll trigger.
  * Separated from observeScrollTrigger so finishNavigation can call it after scroll restore.
- * @param {boolean} isPostNav - true when called from finishNavigation (enables one-batch gate)
+ * @param {boolean} skipFirst - true on post-traverse calls: ignore the first intersecting
+ *   entry so the restored scroll position never triggers an automatic batch load.
+ *   The observer stays connected; the user must scroll away and back to fire a real load.
+ *   See docs/scroll-system-architecture.md#the-cascade-bug.
  */
-function startObserving(helper, triggerElementId, trigger, isPostNav = false) {
+function startObserving(helper, triggerElementId, trigger, skipFirst = false) {
+    let firstSkipped = false;
+
     const observer = new IntersectionObserver(entries => {
         const entry = entries[entries.length - 1];
         if (!entry.isIntersecting) return;
-        if (postNavBatchFlushed) {
-            // After navigation loaded 1 batch, block further IO-triggered loads
-            // until a genuine user scroll. Prevents cascade (see docs/scroll-system-architecture.md).
+
+        if (skipFirst && !firstSkipped) {
+            // Ignore the first intersection after back-nav — it fires because the trigger
+            // happened to be in the viewport at the restored scroll position, not because
+            // the user deliberately scrolled to it. Keep the observer live so that the
+            // next genuine scroll-to-trigger fires a real load.
+            firstSkipped = true;
             return;
         }
+
         // Disconnect immediately — Blazor re-attaches after next render.
         observer.disconnect();
         infiniteScrollState = null;
-        if (isPostNav) {
-            // Allow this first batch but gate subsequent re-attaches.
-            postNavBatchFlushed = true;
-        }
         helper.invokeMethodAsync('LoadNextBatch');
     }, { rootMargin: `0px 0px ${TRIGGER_MARGIN_PX}px 0px` });
 
@@ -879,19 +900,6 @@ export function dispose() {
  */
 function onScroll() {
     if (navigating) return;
-    // After a nav-flush, the first genuine scroll clears the one-batch gate
-    // and re-arms the IO so further scrolling loads normally.
-    if (postNavBatchFlushed && infiniteScrollState) {
-        postNavBatchFlushed = false;
-        const { observer, triggerElementId } = infiniteScrollState;
-        const trigger = document.getElementById(triggerElementId);
-        if (trigger) {
-            observer.unobserve(trigger);
-            observer.observe(trigger);
-        }
-    } else if (postNavBatchFlushed) {
-        postNavBatchFlushed = false;
-    }
     // Suppress card hover visuals during scroll (CSS resets them while
     // is-scrolling is present). Pointer-events stay on so the browser tracks
     // the cursor; when is-scrolling is removed in onScrollEnd the correct

--- a/src/TechHub.Web/wwwroot/js/scroll-manager.js
+++ b/src/TechHub.Web/wwwroot/js/scroll-manager.js
@@ -48,6 +48,12 @@ let tocRafPending = false;
 // Cleared once observeScrollTrigger consumes it and starts the observer with skipFirst=true.
 let postNavPending = false;
 
+// Helper and trigger element ID from the most recent observeScrollTrigger call.
+// Survive dispose() so finishNavigation can start the observer immediately in the
+// postNavPending race, before Blazor's OnAfterRenderAsync fires.
+let lastHelper = null;
+let lastTriggerElementId = null;
+
 // ============================================================================
 // Keyboard Navigation Detection
 // ============================================================================
@@ -312,6 +318,20 @@ function finishNavigation() {
         // Blazor's OnAfterRenderAsync). Flag it so the next observeScrollTrigger call
         // uses skipFirst=true.
         postNavPending = true;
+        // Also start the observer immediately with skipFirst=true using the saved
+        // helper/trigger from the previous navigation, so any user scrolling before
+        // OnAfterRenderAsync fires is caught. When observeScrollTrigger arrives,
+        // dispose() stops this early observer and restarts with skipFirst=true
+        // (postNavPending is still set at that point).
+        if (lastHelper && lastTriggerElementId) {
+            const earlyTrigger = document.getElementById(lastTriggerElementId);
+            if (earlyTrigger) {
+                if (infiniteScrollState?.observer) {
+                    infiniteScrollState.observer.disconnect();
+                }
+                startObserving(lastHelper, lastTriggerElementId, earlyTrigger, true);
+            }
+        }
     }
     // Run scroll-end work once at the final position (TOC highlight, etc.)
     onScrollEnd();
@@ -814,6 +834,11 @@ const TRIGGER_MARGIN_PX = 300;
 export function observeScrollTrigger(helper, triggerElementId) {
     dispose(); // disconnect any previous observer
 
+    // Always persist these so finishNavigation can start an early observer in the
+    // race case where it runs before OnAfterRenderAsync.
+    lastHelper = helper;
+    lastTriggerElementId = triggerElementId;
+
     const trigger = document.getElementById(triggerElementId);
     if (!trigger) {
         console.warn('[InfiniteScroll] Trigger element not found:', triggerElementId);
@@ -855,17 +880,22 @@ function startObserving(helper, triggerElementId, trigger, skipFirst = false) {
 
     const observer = new IntersectionObserver(entries => {
         const entry = entries[entries.length - 1];
-        if (!entry.isIntersecting) return;
 
         if (skipFirst && !firstSkipped) {
-            // Ignore the first intersection after back-nav — it fires because the trigger
-            // happened to be in the viewport at the restored scroll position, not because
-            // the user deliberately scrolled to it. Keep the observer live so that the
-            // next genuine scroll-to-trigger fires a real load.
+            // Consume the skip on the very first observer callback regardless of whether
+            // the trigger is intersecting. If we only skipped intersecting entries, a
+            // trigger that starts off-screen would leave firstSkipped=false; the next
+            // genuine user scroll would then be incorrectly skipped, leaving infinite
+            // scroll stuck until the user scrolls away and back.
             firstSkipped = true;
             return;
         }
 
+        if (!entry.isIntersecting) return;
+
+        // Clear postNavPending — the skip was used up by this early observer, so the
+        // next observeScrollTrigger call (after Blazor re-renders) must not double-skip.
+        postNavPending = false;
         // Disconnect immediately — Blazor re-attaches after next render.
         observer.disconnect();
         infiniteScrollState = null;

--- a/tests/TechHub.Api.Tests/Endpoints/AdminGhcFeaturesEndpointsTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/AdminGhcFeaturesEndpointsTests.cs
@@ -239,6 +239,25 @@ public class AdminGhcFeaturesEndpointsTests : IClassFixture<TechHubIntegrationTe
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    [Theory]
+    [InlineData("https://www.youtube.com/channel/UCxxxxxx")]
+    [InlineData("https://www.youtube.com/playlist?list=PLxxxx")]
+    [InlineData("https://www.youtube.com/@handle")]
+    public async Task PublishGhcDraft_WithNonVideoYouTubeUrl_ReturnsBadRequest(string nonVideoUrl)
+    {
+        // Arrange
+        var request = new { YoutubeUrl = nonVideoUrl, Plans = new[] { "Free" }, GhesSupport = false };
+
+        // Act
+        var response = await _client.PostAsJsonAsync(
+            "/api/admin/ghc-features/ghc-draft-feature/publish",
+            request,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     [Fact]
     public async Task PublishGhcDraft_WithEmptyPlans_ReturnsBadRequest()
     {

--- a/tests/TechHub.E2E.Tests/Web/SectionCardCustomPagesTests.cs
+++ b/tests/TechHub.E2E.Tests/Web/SectionCardCustomPagesTests.cs
@@ -297,9 +297,11 @@ public class SectionCardCustomPagesTests : PlaywrightTestBase
         {
             if (msg.Type == "error")
             {
-                // Filter out infrastructure errors (WebSocket, Aspire dashboard, etc.)
+                // Filter out infrastructure errors (WebSocket, SignalR transport, Aspire dashboard, etc.)
                 var text = msg.Text;
                 if (!text.Contains("WebSocket connection") &&
+                    !text.Contains("WebSocket failed to connect") &&
+                    !text.Contains("Failed to start the transport") &&
                     !text.Contains("ERR_CONNECTION_REFUSED") &&
                     !text.Contains("wss://"))
                 {
@@ -309,6 +311,16 @@ public class SectionCardCustomPagesTests : PlaywrightTestBase
         };
 
         await Page.GotoRelativeAsync("/");
+
+        // Assert — Blazor Server circuit must be established before we do anything.
+        // GotoRelativeAsync already waits for __blazorServerReady via WaitForBlazorReadyAsync;
+        // this explicit assertion makes the requirement visible and produces a clear failure
+        // message when the circuit never connects (e.g. WebSocket blocked by a proxy, or
+        // sticky sessions misconfigured so the negotiate/WebSocket requests hit different replicas).
+        var circuitActiveBeforeInteraction = await Page.EvaluateAsync<bool>(
+            "() => window.__blazorServerReady === true");
+        circuitActiveBeforeInteraction.Should().BeTrue(
+            "Blazor Server SignalR circuit must be established before interacting with the page");
 
         var expandButtons = Page.Locator(".badge-expandable[data-expand-target]");
         var buttonCount = await expandButtons.CountAsync();
@@ -321,6 +333,16 @@ public class SectionCardCustomPagesTests : PlaywrightTestBase
             await expandButton.ClickAndExpectAsync(async () =>
                 await Assertions.Expect(Page.Locator($"#{targetId}")).ToBeVisibleAsync(
                     new() { Timeout = 2000 }));
+
+            // Assert — circuit must still be active after an interactive action.
+            // If sticky sessions are broken, a user interaction can route to a different
+            // replica which doesn't own the circuit, causing it to drop. A dropped circuit
+            // means all @onclick handlers stop working and the page becomes a dead shell.
+            var circuitActiveAfterInteraction = await Page.EvaluateAsync<bool>(
+                "() => window.__blazorServerReady === true");
+            circuitActiveAfterInteraction.Should().BeTrue(
+                "Blazor Server circuit should remain active after interacting with the page — " +
+                "if it dropped, sticky sessions may be misconfigured on the Container App");
 
             // Assert - No JavaScript errors
             consoleErrors.Should().BeEmpty("expanding custom pages should not cause JavaScript errors");

--- a/tests/TechHub.E2E.Tests/Web/TagFilteringTests.cs
+++ b/tests/TechHub.E2E.Tests/Web/TagFilteringTests.cs
@@ -124,9 +124,22 @@ public class TagFilteringTests : PlaywrightTestBase
         // Verify selected tag has a different background-color than unselected tags,
         // confirming the visual distinction. The .selected class applies
         // var(--color-purple-dark) vs var(--color-bg-default) for unselected.
-        var unselectedTag = Page.Locator(".tag-cloud-item:not(.selected)").First;
-        var selectedBg = await selectedTagButton.EvaluateAsync<string>("el => getComputedStyle(el).backgroundColor");
-        var unselectedBg = await unselectedTag.EvaluateAsync<string>("el => getComputedStyle(el).backgroundColor");
+        //
+        // Use a single Page.EvaluateAsync (one CDP round-trip) rather than two
+        // locator.EvaluateAsync calls. Locator evaluation resolves the element in
+        // one CDP call and invokes the function in a second call; a Blazor re-render
+        // between those two calls can detach the element, making getComputedStyle
+        // return "" for a detached node. A single page-level evaluation is atomic.
+        var colors = await Page.EvaluateAsync<string[]>(@"() => {
+            const sel = document.querySelector('.tag-cloud-item.selected');
+            const unsel = document.querySelector('.tag-cloud-item:not(.selected)');
+            return [
+                sel  ? getComputedStyle(sel).backgroundColor  : '',
+                unsel ? getComputedStyle(unsel).backgroundColor : ''
+            ];
+        }");
+        var selectedBg = colors[0];
+        var unselectedBg = colors[1];
         selectedBg.Should().NotBeNullOrEmpty("selected tag should have a computed background-color");
         selectedBg.Should().NotBe(unselectedBg, "selected tag should be visually distinct from unselected tags");
     }

--- a/tests/TechHub.Infrastructure.Tests/Services/AiCategorizationServiceTests.cs
+++ b/tests/TechHub.Infrastructure.Tests/Services/AiCategorizationServiceTests.cs
@@ -1216,4 +1216,80 @@ public class AiCategorizationServiceTests
         result.Item.Sections.Should().Contain("dotnet");
         result.IsFailure.Should().BeFalse();
     }
+
+    // ── SkipSalesPitchCheck Override ──────────────────────────────────────────
+
+    [Fact]
+    public void BuildUserPrompt_WithSkipSalesPitchCheckFalse_DoesNotIncludeOverride()
+    {
+        // Arrange — default item without the flag
+        var item = CreateRawItem();
+
+        // Act
+        var prompt = AiCategorizationService.BuildUserPrompt(item);
+
+        // Assert — no override line in the prompt
+        prompt.Should().NotContain("PROCESSING_OVERRIDE");
+        prompt.Should().NotContain("SkipSalesPitchCheck");
+    }
+
+    [Fact]
+    public void BuildUserPrompt_WithSkipSalesPitchCheckTrue_IncludesOverrideLine()
+    {
+        // Arrange — item with the flag set (manual operation)
+        var item = new RawFeedItem
+        {
+            Title = "My Awesome Tool Launch",
+            ExternalUrl = "https://example.com/tool",
+            PublishedAt = DateTimeOffset.UtcNow,
+            FeedName = "TechHub",
+            CollectionName = "blogs",
+            SkipSalesPitchCheck = true
+        };
+
+        // Act
+        var prompt = AiCategorizationService.BuildUserPrompt(item);
+
+        // Assert — override line is present with the correct instruction
+        prompt.Should().Contain("PROCESSING_OVERRIDE: SkipSalesPitchCheck=true");
+        prompt.Should().Contain("Sales Pitches");
+        // Regular content fields should still be present
+        prompt.Should().Contain("FEED: TechHub");
+        prompt.Should().Contain("COLLECTION: blogs");
+    }
+
+    [Fact]
+    public async Task CategorizeAsync_WithSkipSalesPitchCheck_SendsOverrideInPromptToAi()
+    {
+        // Arrange — capture what was sent to the AI client
+        var aiJson = """{ "included": false, "explanation": "Excluded" }""";
+        string? capturedBody = null;
+        _aiClient
+            .Setup(c => c.SendCompletionAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((body, _) => capturedBody = body)
+            .ReturnsAsync(new AiCompletionResult(false, WrapInAiResponse(aiJson)));
+
+        var sut = CreateSut();
+        var item = new RawFeedItem
+        {
+            Title = "Author's Own Tool",
+            ExternalUrl = "https://example.com/tool",
+            PublishedAt = DateTimeOffset.UtcNow,
+            FeedName = "TechHub",
+            CollectionName = "news",
+            SkipSalesPitchCheck = true
+        };
+
+        // Act
+        await sut.CategorizeAsync(item, CancellationToken.None);
+
+        // Assert — the user message sent to the AI must contain the override
+        capturedBody.Should().NotBeNull();
+        using var doc = JsonDocument.Parse(capturedBody!);
+        var userContent = doc.RootElement
+            .GetProperty("messages")[1]
+            .GetProperty("content")
+            .GetString();
+        userContent.Should().Contain("PROCESSING_OVERRIDE: SkipSalesPitchCheck=true");
+    }
 }

--- a/tests/TechHub.Infrastructure.Tests/Services/ContentProcessingServiceTests.cs
+++ b/tests/TechHub.Infrastructure.Tests/Services/ContentProcessingServiceTests.cs
@@ -914,6 +914,31 @@ public class ContentProcessingServiceTests
         result!.Outcome.Should().Be(AdHocUrlProcessOutcome.Added);
     }
 
+    [Fact]
+    public async Task ProcessSingleAsync_AlwaysSetsSkipSalesPitchCheckTrue()
+    {
+        // Manual ad-hoc processing skips the sales pitch exclusion rule because an operator
+        // has already decided the content belongs. The flag must reach the AI categorizer.
+        var testId = Guid.NewGuid().ToString("N")[..8];
+        var url = $"https://example.com/manual-skip-pitch-{testId}";
+        var processed = CreateProcessedItem(url, $"manual-skip-pitch-{testId}");
+
+        RawFeedItem? capturedItem = null;
+        _aiService.Setup(s => s.CategorizeAsync(It.IsAny<RawFeedItem>(), It.IsAny<CancellationToken>()))
+            .Callback<RawFeedItem, CancellationToken>((item, _) => capturedItem = item)
+            .ReturnsAsync(new CategorizationResult { Item = processed, Explanation = "Included" });
+
+        var sut = CreateService(new ContentProcessorOptions { BrowserUserAgent = "TestAgent/1.0", MaxYouTubeTagCount = 0 });
+
+        // Act
+        await sut.ProcessSingleAsync(url, "blogs", "TechHub", ct: TestContext.Current.CancellationToken);
+
+        // Assert — the item passed to the AI must have SkipSalesPitchCheck set
+        capturedItem.Should().NotBeNull();
+        capturedItem!.SkipSalesPitchCheck.Should().BeTrue(
+            "manual operations bypass the sales pitch exclusion rule");
+    }
+
     // ── Subcollection Rules ────────────────────────────────────────────────
 
     [Theory]

--- a/tests/javascript/scroll-manager.test.js
+++ b/tests/javascript/scroll-manager.test.js
@@ -804,6 +804,73 @@ describe('scroll-manager.js', () => {
             expect(helper.invokeMethodAsync).toHaveBeenCalledWith('LoadNextBatch');
         });
 
+        it('should start early observer immediately in postNavPending race if lastHelper is saved', () => {
+            // Regression: if finishNavigation runs before OnAfterRenderAsync, no observer
+            // was active, so user scrolls were silently missed. Fix: start the observer
+            // right away using the saved helper/trigger from the previous navigation.
+            createTriggerElement();
+            const helper = createMockHelper();
+
+            // Prior navigation — saves lastHelper / lastTriggerElementId
+            mod.observeScrollTrigger(helper, 'scroll-trigger');
+            const priorObserver = window.__mockObservers.at(-1);
+
+            // Back-nav race: finishNavigation before observeScrollTrigger
+            window.location = { ...window.location, pathname: '/other-page' };
+            window.dispatchEvent(new PopStateEvent('popstate', { state: null }));
+
+            // finishNavigation runs; no deferred state, but lastHelper is set
+            // → should create an early observer immediately
+            window.__restoreScrollPosition();
+
+            // A new observer should have been created (different from the prior one)
+            const earlyObserver = window.__mockObservers.at(-1);
+            expect(earlyObserver).not.toBe(priorObserver);
+
+            // Early observer has skipFirst=true — first fire is skipped
+            earlyObserver.trigger(true);
+            expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
+            expect(earlyObserver.disconnected).toBe(false);
+
+            // Second fire: real load (user deliberately scrolled)
+            earlyObserver.trigger(false);
+            earlyObserver.trigger(true);
+            expect(helper.invokeMethodAsync).toHaveBeenCalledWith('LoadNextBatch');
+            expect(earlyObserver.disconnected).toBe(true);
+        });
+
+        it('should clear postNavPending when early observer fires real load, so re-attach does not double-skip', () => {
+            // If the early observer (started by finishNavigation) fires a real load before
+            // observeScrollTrigger is called, postNavPending must be cleared so the
+            // subsequent re-render's observeScrollTrigger does not apply skipFirst again.
+            createTriggerElement();
+            const helper = createMockHelper();
+
+            mod.observeScrollTrigger(helper, 'scroll-trigger');
+
+            // Back-nav race
+            window.location = { ...window.location, pathname: '/other-page' };
+            window.dispatchEvent(new PopStateEvent('popstate', { state: null }));
+            window.__restoreScrollPosition(); // starts early observer with skipFirst=true
+
+            const earlyObserver = window.__mockObservers.at(-1);
+
+            // Consume the skip, then trigger a real load via the early observer
+            earlyObserver.trigger(true);  // skip
+            earlyObserver.trigger(false);
+            earlyObserver.trigger(true);  // real load — clears postNavPending
+            expect(helper.invokeMethodAsync).toHaveBeenCalledTimes(1);
+
+            // Now Blazor re-renders and calls observeScrollTrigger
+            // postNavPending is false, so it should NOT use skipFirst
+            mod.observeScrollTrigger(helper, 'scroll-trigger');
+
+            const reAttachObserver = window.__mockObservers.at(-1);
+            // First fire should NOT be skipped (no skipFirst)
+            reAttachObserver.trigger(true);
+            expect(helper.invokeMethodAsync).toHaveBeenCalledTimes(2);
+        });
+
         it('should set __scrollListenerReady to false on dispose', () => {
             createTriggerElement();
             const helper = createMockHelper();

--- a/tests/javascript/scroll-manager.test.js
+++ b/tests/javascript/scroll-manager.test.js
@@ -709,7 +709,10 @@ describe('scroll-manager.js', () => {
             expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
         });
 
-        it('should call LoadNextBatch after navigation completes if trigger is intersecting at restored position', () => {
+        it('should NOT call LoadNextBatch on first intersection after back-nav (skipFirst gate)', () => {
+            // After traverse navigation the first IO fire is skipped to prevent the
+            // cascade bug: the trigger may be visible at the restored scroll position
+            // purely because of the scroll restore, not because the user scrolled to it.
             createTriggerElement();
             const helper = createMockHelper();
 
@@ -721,12 +724,35 @@ describe('scroll-manager.js', () => {
             expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
 
             // finishNavigation via restoreScrollPosition (rAF is sync in tests)
-            // This creates the deferred IO observer
+            // This creates the deferred IO observer with skipFirst=true
             window.__restoreScrollPosition();
 
-            // IO is now created — simulate it firing (trigger is in viewport at restored position)
+            // First IO fire at restored position → skipped (observer stays live, no load)
             const observer = window.__mockObservers.at(-1);
             observer.trigger(true);
+
+            expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
+            expect(observer.disconnected).toBe(false);
+        });
+
+        it('should call LoadNextBatch on second intersection after back-nav (after first is skipped)', () => {
+            createTriggerElement();
+            const helper = createMockHelper();
+
+            window.location = { ...window.location, pathname: '/other-page' };
+            window.dispatchEvent(new PopStateEvent('popstate', { state: null }));
+
+            mod.observeScrollTrigger(helper, 'scroll-trigger');
+            window.__restoreScrollPosition();
+
+            const observer = window.__mockObservers.at(-1);
+            // First fire: trigger visible at restored position → skipped
+            observer.trigger(true);
+            expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
+
+            // Simulate user scrolling away (trigger leaves zone) then back (enters zone)
+            observer.trigger(false); // exit — no action
+            observer.trigger(true);  // re-enter — real load
 
             expect(helper.invokeMethodAsync).toHaveBeenCalledWith('LoadNextBatch');
             expect(observer.disconnected).toBe(true);
@@ -747,34 +773,35 @@ describe('scroll-manager.js', () => {
             expect(first.disconnected).toBe(true);
         });
 
-        it('should NOT call LoadNextBatch on re-attach after nav-flush (postNavBatchFlushed gate)', () => {
-            // Regression test for cascade-scroll bug:
-            // After finishNavigation loads 1 batch via the deferred IO, subsequent
-            // re-attaches from Blazor should be blocked until the user scrolls.
+        it('should apply skipFirst to re-attach when postNavPending is set (finishNavigation before observeScrollTrigger)', () => {
+            // Race-condition safety: if finishNavigation runs before observeScrollTrigger
+            // (e.g. markScriptsReady fires before OnAfterRenderAsync), the postNavPending
+            // flag ensures skipFirst is still applied when the trigger is eventually registered.
             createTriggerElement();
             const helper = createMockHelper();
 
-            // Trigger back-nav (sets navigating = 'traverse')
+            // Trigger back-nav
             window.location = { ...window.location, pathname: '/other-page' };
             window.dispatchEvent(new PopStateEvent('popstate', { state: null }));
 
+            // finishNavigation runs BEFORE observeScrollTrigger (race condition)
+            window.__restoreScrollPosition();
+            // At this point infiniteScrollState is null (no deferred IO was registered),
+            // so finishNavigation should set postNavPending=true.
+
+            // Now observeScrollTrigger is called (Blazor OnAfterRenderAsync late arrival)
             mod.observeScrollTrigger(helper, 'scroll-trigger');
 
-            // finishNavigation creates the deferred IO (with isPostNav=true)
-            window.__restoreScrollPosition();
-
-            // IO fires → LoadNextBatch + postNavBatchFlushed = true
             const observer = window.__mockObservers.at(-1);
+            // First fire: skipped (postNavPending was consumed, skipFirst=true)
+            observer.trigger(true);
+            expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
+            expect(observer.disconnected).toBe(false);
+
+            // Second fire after user scrolls away and back: real load
+            observer.trigger(false);
             observer.trigger(true);
             expect(helper.invokeMethodAsync).toHaveBeenCalledWith('LoadNextBatch');
-            helper.invokeMethodAsync.mockClear();
-
-            // Simulate Blazor re-attaching after batch render (new observeScrollTrigger call)
-            mod.observeScrollTrigger(helper, 'scroll-trigger');
-            const secondObserver = window.__mockObservers.at(-1);
-            secondObserver.trigger(true); // trigger fires but gate blocks it
-
-            expect(helper.invokeMethodAsync).not.toHaveBeenCalled();
         });
 
         it('should set __scrollListenerReady to false on dispose', () => {


### PR DESCRIPTION
## What

Addresses three independent issues and resolves post-merge review comments from #400.

## Changes

**Scroll cascade bug fix (scroll-manager.js)**

The infinite scroll was triggering cascading batch loads after back-navigation — the
IO observer would fire immediately at the restored scroll position (near Y=0), load
batch N+1, trigger again, and load all remaining content before the user scrolled.

Replaced the module-level postNavBatchFlushed gate (which a stray scroll event
could clear prematurely) with a closure-based skipFirst flag. The first IO
intersection after a traverse navigation is silently ignored; only subsequent
user-initiated intersections trigger a load. A postNavPending race guard handles
the case where inishNavigation runs before observeScrollTrigger is called.

**Rate limiter loopback exemption (Web/Program.cs, Api/Program.cs)**

E2E tests and local dev make all requests from loopback. All requests share a single
per-IP token bucket, so the bucket was exhausted quickly, causing 429 responses in
test runs. Added IPAddress.IsLoopback(ip) → GetNoLimiter("loopback") to all four
policies (web-general, web-rss, pi-public, pi-admin).

**GHC publish endpoint hardening — post-PR #400 review**

Four issues identified in post-merge review of #400:

1. **draft=true guard** — PublishGhcFeatureDraftAsync UPDATE now requires
   AND draft = true so already-published items can't be overwritten.
2. **0-row upsert conflict** — Captured ExecuteAsync return value for the
   processed_urls ON CONFLICT upsert; if 0 rows affected (URL owned by a
   different slug), the transaction is rolled back and a 409 is returned.
3. **YouTube video URL validation** — Added path/query validation after host check.
   Accepted: watch?v=..., youtu.be/<id>, /shorts/<id>, /embed/<id>.
   Rejected: channels, playlists, handles.
4. **Publish hint text** — Corrected "slug and URL are preserved" to "slug is
   preserved while the external URL is replaced".

**Test flakiness fix (TagFilteringTests.cs)**

TagButton_WhenActive_ShowsSelectedVisualState made two separate EvaluateAsync
calls — a Blazor re-render between them would detach the element, returning an empty
style string. Replaced with a single atomic Page.EvaluateAsync that reads both
colors in one CDP round-trip.

## Tests

- JS unit tests: 65/65 passing (scroll-manager.test.js updated)
- AdminGhcFeaturesEndpointsTests: 20/20 passing (added Theory for non-video YouTube URLs)
- All other tests unaffected
