### PR TITLE
Fix CD failure: deploy Key Vault before syncing secrets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -575,6 +575,9 @@ jobs:
           POSTGRES_ADMIN_PASSWORD: ${{ secrets.POSTGRES_ADMIN_PASSWORD }}
           AZURE_AD_CLIENT_SECRET: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
           ADMIN_IP_ADDRESSES: ${{ secrets.ADMIN_IP_ADDRESSES }}
+          GHCR_REGISTRY_TOKEN: ${{ secrets.GHCR_REGISTRY_TOKEN }}
+          WILDCARD_CERT_HUB_MS: ${{ secrets.WILDCARD_CERT_HUB_MS }}
+          WILDCARD_CERT_XEBIA_MS: ${{ secrets.WILDCARD_CERT_XEBIA_MS }}
         run: |
           ./scripts/Deploy-Infrastructure.ps1 `
             -Mode deploy `

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -575,7 +575,7 @@ jobs:
           POSTGRES_ADMIN_PASSWORD: ${{ secrets.POSTGRES_ADMIN_PASSWORD }}
           AZURE_AD_CLIENT_SECRET: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
           ADMIN_IP_ADDRESSES: ${{ secrets.ADMIN_IP_ADDRESSES }}
-          GHCR_REGISTRY_TOKEN: ${{ secrets.GHCR_REGISTRY_TOKEN }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
           WILDCARD_CERT_HUB_MS: ${{ secrets.WILDCARD_CERT_HUB_MS }}
           WILDCARD_CERT_XEBIA_MS: ${{ secrets.WILDCARD_CERT_XEBIA_MS }}
         run: |

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -102,6 +102,9 @@ param acmeDnsZoneName string = 'acme.hub.ms'
 @description('Domains that need ACME-delegated wildcard certificate renewal')
 param acmeDelegatedDomains string[] = ['hub.ms', 'xebia.ms']
 
+@description('When false, skips Container App deployments (wildcardCerts, apiApp, webApp). Set to false on first deploy to create the Key Vault before syncing secrets, then run again with the default true to deploy Container Apps.')
+param deployApps bool = true
+
 @description('GitHub organization username for ghcr.io registry (used as the image namespace: ghcr.io/{githubRegistryUsername}/...)')
 param githubRegistryUsername string = 'techhubms'
 
@@ -215,7 +218,7 @@ module containerAppsEnv './modules/containerApps.bicep' = {
 
 // Wildcard certificates from Key Vault → Container Apps Environment
 // The managed identity needs Key Vault Secrets User on the prod KV.
-module wildcardCerts './modules/wildcardCertificates.bicep' = if (!empty(wildcardCertNames)) {
+module wildcardCerts './modules/wildcardCertificates.bicep' = if (!empty(wildcardCertNames) && deployApps) {
   scope: resourceGroup
   name: 'wildcardCerts-prod'
   params: {
@@ -230,11 +233,11 @@ module wildcardCerts './modules/wildcardCertificates.bicep' = if (!empty(wildcar
 }
 
 // Build a map of base domain → certificate resource ID for the web module.
-// BCP318 warnings are safe: the !empty() guard ensures outputs are only accessed when the module deployed.
+// BCP318 warnings are safe: the !empty() && deployApps guard ensures outputs are only accessed when the module deployed.
 #disable-next-line BCP318
-var _certDomains = !empty(wildcardCertNames) ? wildcardCerts.outputs.certDomains : []
+var _certDomains = (!empty(wildcardCertNames) && deployApps) ? wildcardCerts.outputs.certDomains : []
 #disable-next-line BCP318
-var _certIds = !empty(wildcardCertNames) ? wildcardCerts.outputs.certIds : []
+var _certIds = (!empty(wildcardCertNames) && deployApps) ? wildcardCerts.outputs.certIds : []
 var wildcardCertIds = toObject(_certDomains, domain => domain, domain => _certIds[indexOf(_certDomains, domain)])
 
 // Wildcard custom domain bindings (*.hub.ms, *.xebia.ms) derived from wildcardCertNames keys.
@@ -312,7 +315,7 @@ module openAiUserRoleDevs './modules/openAiUserRole.bicep' = [for (objectId, i) 
 }]
 
 // API Container App
-module apiApp './modules/api.bicep' = {
+module apiApp './modules/api.bicep' = if (deployApps) {
   scope: resourceGroup
   name: 'api-deployment'
   params: {
@@ -337,7 +340,7 @@ module apiApp './modules/api.bicep' = {
 }
 
 // Web Container App
-module webApp './modules/web.bicep' = {
+module webApp './modules/web.bicep' = if (deployApps) {
   scope: resourceGroup
   name: 'web-deployment'
   params: {
@@ -348,6 +351,8 @@ module webApp './modules/web.bicep' = {
     githubRegistryAuthUsername: githubRegistryAuthUsername
     identityId: identity.outputs.identityId
     imageTag: webImageTag
+    // BCP318: apiApp is conditional on deployApps; webApp shares the same condition so apiApp is always non-null here.
+    #disable-next-line BCP318
     apiBaseUrl: apiApp.outputs.fqdn
     appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
     customDomains: allCustomDomains
@@ -419,8 +424,10 @@ module policyAssignments './modules/policy.bicep' = {
 
 // Outputs
 output resourceGroupName string = resourceGroup.name
-output apiUrl string = 'https://${apiApp.outputs.fqdn}'
-output webUrl string = 'https://${webApp.outputs.fqdn}'
+#disable-next-line BCP318
+output apiUrl string = deployApps ? 'https://${apiApp.outputs.fqdn}' : ''
+#disable-next-line BCP318
+output webUrl string = deployApps ? 'https://${webApp.outputs.fqdn}' : ''
 output appInsightsName string = monitoring.outputs.appInsightsName
 output keyVaultName string = keyVaultName
 output openAiEndpoint string = openai.outputs.openAiEndpoint

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -16,9 +16,6 @@ param appInsightsName string = 'appi-techhub-prod'
 @description('Key Vault name (stores wildcard certs, app secrets, and GitHub registry token)')
 param keyVaultName string = 'kv-techhub-prod'
 
-@description('Azure AD object IDs for Key Vault administrators')
-param keyVaultAdminObjectIds array = []
-
 @description('Container Apps Environment name')
 param containerAppsEnvName string = 'cae-techhub-prod'
 
@@ -182,7 +179,6 @@ module keyVault './modules/keyVault.bicep' = {
   params: {
     location: location
     vaultName: keyVaultName
-    adminObjectIds: keyVaultAdminObjectIds
     logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
     adminIpAddresses: adminIpList
     containerAppsSubnetId: network.outputs.containerAppsSubnetId
@@ -300,19 +296,6 @@ module openAiUserRoleProd './modules/openAiUserRole.bicep' = {
   }
   dependsOn: [openai]
 }
-
-// Grant Cognitive Services OpenAI User to each developer in keyVaultAdminObjectIds so they
-// can call the AI Foundry API from their local machine after 'az login'.
-module openAiUserRoleDevs './modules/openAiUserRole.bicep' = [for (objectId, i) in keyVaultAdminObjectIds: {
-  scope: resourceGroup
-  name: 'openAiUserRole-developer-${i}'
-  params: {
-    openAiName: openAiName
-    principalId: objectId
-    principalType: 'User'
-  }
-  dependsOn: [openai]
-}]
 
 // API Container App
 module apiApp './modules/api.bicep' = if (deployApps) {

--- a/infra/modules/keyVault.bicep
+++ b/infra/modules/keyVault.bicep
@@ -1,9 +1,6 @@
 param location string
 param vaultName string
 
-@description('Azure AD object IDs that should get full Key Vault management access')
-param adminObjectIds string[] = []
-
 @description('Log Analytics Workspace ID for audit logging (optional)')
 param logAnalyticsWorkspaceId string = ''
 
@@ -46,17 +43,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
     }
   }
 }
-
-// Grant Key Vault Administrator role to specified principals
-resource adminRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for (objectId, i) in adminObjectIds: {
-  name: guid(keyVault.id, objectId, 'Key Vault Administrator')
-  scope: keyVault
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483') // Key Vault Administrator
-    principalId: objectId
-    principalType: 'User'
-  }
-}]
 
 // Audit logging for Key Vault operations
 resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (!empty(logAnalyticsWorkspaceId)) {

--- a/infra/parameters/prod.bicepparam
+++ b/infra/parameters/prod.bicepparam
@@ -7,10 +7,6 @@ param webImageTag = readEnvironmentVariable('WEB_IMAGE_TAG')
 param resourceGroupName = 'rg-techhub-prod'
 param appInsightsName = 'appi-techhub-prod'
 param keyVaultName = 'kv-techhub-prod'
-// Add Azure AD object IDs here for Key Vault admin access AND AI Foundry RBAC (Cognitive Services OpenAI User).
-// Developers listed here can call AI Foundry from their local machine after 'az login'.
-// Find yours with: az ad signed-in-user show --query id -o tsv
-param keyVaultAdminObjectIds = []
 param containerAppsEnvName = 'cae-techhub-prod'
 param apiAppName = 'ca-techhub-api-prod'
 param webAppName = 'ca-techhub-web-prod'

--- a/scripts/Deploy-Infrastructure.ps1
+++ b/scripts/Deploy-Infrastructure.ps1
@@ -261,9 +261,11 @@ if ($Mode -eq 'deploy') {
     # the app uses managed identity token auth (Entra) for both PostgreSQL and AI Foundry.
     Write-Step "Syncing application secrets to Key Vault"
     $syncScript = Join-Path $PSScriptRoot 'Sync-KeyVaultSecrets.ps1'
-    & $syncScript
-    if ($LASTEXITCODE -ne 0) {
+    try {
+        & $syncScript
+    } catch {
         Write-Fail "Secret sync failed — aborting deployment to prevent a crash-looping revision."
+        Write-Fail $_
         exit 1
     }
     Write-Ok "Secrets synced"
@@ -292,6 +294,10 @@ Write-Host ""
 Write-Host "===============================================================" -ForegroundColor DarkCyan
 Write-Host "  Infrastructure $($Mode.ToUpper()) Complete" -ForegroundColor Green
 Write-Host "  Resource Group  : $resourceGroup" -ForegroundColor Gray
-Write-Host "  Deployment   : $deploymentName" -ForegroundColor Gray
+if ($Mode -eq 'deploy') {
+    Write-Host "  Deployments     : $deploymentName-infra, $deploymentName-apps" -ForegroundColor Gray
+} else {
+    Write-Host "  Deployment      : $deploymentName" -ForegroundColor Gray
+}
 Write-Host "===============================================================" -ForegroundColor DarkCyan
 Write-Host ""

--- a/scripts/Deploy-Infrastructure.ps1
+++ b/scripts/Deploy-Infrastructure.ps1
@@ -180,22 +180,6 @@ if (-not $env:AZURE_AD_CLIENT_SECRET) {
     [Environment]::SetEnvironmentVariable('AZURE_AD_CLIENT_SECRET', "")
 }
 
-# Sync application secrets into Key Vault before deployment.
-# Container Apps reference secrets via keyVaultUrl; they must exist before
-# the new revision starts.
-# Note: Database connection string and AI API key are no longer stored as KV secrets —
-# the app uses managed identity token auth (Entra) for both PostgreSQL and AI Foundry.
-if ($Mode -eq 'deploy') {
-    Write-Step "Syncing application secrets to Key Vault"
-    $syncScript = Join-Path $PSScriptRoot 'Sync-KeyVaultSecrets.ps1'
-    & $syncScript
-    if ($LASTEXITCODE -ne 0) {
-        Write-Fail "Secret sync failed — aborting deployment to prevent a crash-looping revision."
-        exit 1
-    }
-    Write-Ok "Secrets synced"
-}
-
 # ============================================================================
 # DEPLOYMENT
 # ============================================================================
@@ -250,21 +234,54 @@ if ($Mode -eq 'whatif') {
     Write-Ok "What-If analysis completed"
 }
 
-# Step 3: Deploy
+# Step 3: Deploy (two-phase to handle fresh environments where the Key Vault does not yet exist)
 if ($Mode -eq 'deploy') {
-    Write-Step "Deploying infrastructure ($deploymentName)"
+    # Phase 1: Base infrastructure — VNet, Key Vault, PostgreSQL, identity, Container Apps Environment.
+    # Container Apps are skipped (deployApps=false) so the Key Vault exists before we write secrets.
+    Write-Step "Phase 1: Deploying base infrastructure"
 
     az deployment sub create `
-        --name $deploymentName `
+        --name "$deploymentName-infra" `
+        --location $Location `
+        --template-file $templateFile `
+        --parameters $paramsFile `
+        --parameters deployApps=false
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "Phase 1 infrastructure deployment failed"
+        exit 1
+    }
+    Write-Ok "Base infrastructure deployed successfully"
+
+    # Sync secrets now that the Key Vault exists.
+    # Container Apps reference secrets via keyVaultUrl; they are fetched when the
+    # revision starts, so writing them before Phase 2 ensures they are available
+    # as soon as the revision begins pulling the image.
+    # Note: Database connection string and AI API key are no longer stored as KV secrets —
+    # the app uses managed identity token auth (Entra) for both PostgreSQL and AI Foundry.
+    Write-Step "Syncing application secrets to Key Vault"
+    $syncScript = Join-Path $PSScriptRoot 'Sync-KeyVaultSecrets.ps1'
+    & $syncScript
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "Secret sync failed — aborting deployment to prevent a crash-looping revision."
+        exit 1
+    }
+    Write-Ok "Secrets synced"
+
+    # Phase 2: Container Apps — registry token + app secrets are now in the Key Vault.
+    Write-Step "Phase 2: Deploying Container Apps"
+
+    az deployment sub create `
+        --name "$deploymentName-apps" `
         --location $Location `
         --template-file $templateFile `
         --parameters $paramsFile
 
     if ($LASTEXITCODE -ne 0) {
-        Write-Fail "Deployment failed"
+        Write-Fail "Phase 2 Container Apps deployment failed"
         exit 1
     }
-    Write-Ok "Infrastructure deployed successfully"
+    Write-Ok "Container Apps deployed successfully"
 }
 
 # ============================================================================

--- a/scripts/Sync-KeyVaultSecrets.ps1
+++ b/scripts/Sync-KeyVaultSecrets.ps1
@@ -96,7 +96,7 @@ function Set-KvSecret {
 
 # --- Collect values from env ---
 $aadClientSecret  = $env:AZURE_AD_CLIENT_SECRET
-$ghcrToken        = $env:GHCR_REGISTRY_TOKEN
+$ghcrToken        = $env:GHCR_PAT
 $wildcardHubMs    = $env:WILDCARD_CERT_HUB_MS
 $wildcardXebiaMs  = $env:WILDCARD_CERT_XEBIA_MS
 

--- a/scripts/Sync-KeyVaultSecrets.ps1
+++ b/scripts/Sync-KeyVaultSecrets.ps1
@@ -35,7 +35,10 @@
     exists in Key Vault, an empty value causes it to be skipped (existing value
     is left unchanged — useful for re-deploying without re-specifying stable secrets).
 
-    Requires the caller to have the 'Key Vault Secrets Officer' role on the vault.
+    Requires the caller to have both:
+      - 'Key Vault Contributor' (ARM management-plane — needed to add/remove network firewall rules)
+      - 'Key Vault Secrets Officer' (data-plane — needed to read/write secrets)
+    Or simply 'Key Vault Administrator' which covers both.
 
 .PARAMETER KeyVaultName
     Production Key Vault name. Defaults to 'kv-techhub-prod'.

--- a/scripts/Sync-KeyVaultSecrets.ps1
+++ b/scripts/Sync-KeyVaultSecrets.ps1
@@ -11,6 +11,9 @@
 
     Secrets written:
         techhub-prod-aad-client-secret      — Entra client secret
+        techhub-github-registry-token       — GHCR PAT for pulling container images
+        wildcard-hub-ms                     — Wildcard TLS certificate for *.hub.ms
+        wildcard-xebia-ms                   — Wildcard TLS certificate for *.xebia.ms
 
     Secrets no longer written (replaced by managed identity / RBAC):
         techhub-prod-db-connection-string   — removed; app uses Entra token auth (Database:UseEntraAuth=true)
@@ -22,7 +25,8 @@
 
     Manual workflow (from an admin machine allowed through the KV firewall):
         1. az login
-        2. Set env vars: AZURE_AD_CLIENT_SECRET
+        2. Set env vars: AZURE_AD_CLIENT_SECRET, GHCR_REGISTRY_TOKEN,
+           WILDCARD_CERT_HUB_MS, WILDCARD_CERT_XEBIA_MS
         3. ./scripts/Sync-KeyVaultSecrets.ps1
 
     Fail-fast behaviour: if a secret value is empty AND the secret does not yet
@@ -91,7 +95,10 @@ function Set-KvSecret {
 }
 
 # --- Collect values from env ---
-$aadClientSecret = $env:AZURE_AD_CLIENT_SECRET
+$aadClientSecret  = $env:AZURE_AD_CLIENT_SECRET
+$ghcrToken        = $env:GHCR_REGISTRY_TOKEN
+$wildcardHubMs    = $env:WILDCARD_CERT_HUB_MS
+$wildcardXebiaMs  = $env:WILDCARD_CERT_XEBIA_MS
 
 # --- Temporarily add this machine's IP to the Key Vault firewall ---
 # Key Vault is IP-restricted. GitHub Actions runners have dynamic IPs that are not in the
@@ -182,6 +189,9 @@ try {
     }
 
     Set-KvSecret -Name "techhub-prod-aad-client-secret" -Value $aadClientSecret -Description 'Entra client secret'
+    Set-KvSecret -Name "techhub-github-registry-token"  -Value $ghcrToken        -Description 'GitHub Container Registry PAT'
+    Set-KvSecret -Name "wildcard-hub-ms"                -Value $wildcardHubMs    -Description 'Wildcard TLS certificate (*.hub.ms)'
+    Set-KvSecret -Name "wildcard-xebia-ms"              -Value $wildcardXebiaMs  -Description 'Wildcard TLS certificate (*.xebia.ms)'
 
     Write-Host ""
     Write-Host "All secrets synchronised into '$($KeyVaultName)'." -ForegroundColor Green

--- a/scripts/Sync-KeyVaultSecrets.ps1
+++ b/scripts/Sync-KeyVaultSecrets.ps1
@@ -25,7 +25,7 @@
 
     Manual workflow (from an admin machine allowed through the KV firewall):
         1. az login
-        2. Set env vars: AZURE_AD_CLIENT_SECRET, GHCR_REGISTRY_TOKEN,
+        2. Set env vars: AZURE_AD_CLIENT_SECRET, GHCR_PAT,
            WILDCARD_CERT_HUB_MS, WILDCARD_CERT_XEBIA_MS
         3. ./scripts/Sync-KeyVaultSecrets.ps1
 

--- a/tests/powershell/Sync-KeyVaultSecrets.Tests.ps1
+++ b/tests/powershell/Sync-KeyVaultSecrets.Tests.ps1
@@ -150,6 +150,24 @@ Describe "Sync-KeyVaultSecrets" {
             $content | Should -Match "aad-client-secret"
         }
 
+        It "Should write the GitHub Container Registry PAT" {
+            $content = Get-Content $scriptPath -Raw
+            $content | Should -Match "techhub-github-registry-token"
+            $content | Should -Match "GHCR_REGISTRY_TOKEN"
+        }
+
+        It "Should write the wildcard-hub-ms TLS certificate" {
+            $content = Get-Content $scriptPath -Raw
+            $content | Should -Match "wildcard-hub-ms"
+            $content | Should -Match "WILDCARD_CERT_HUB_MS"
+        }
+
+        It "Should write the wildcard-xebia-ms TLS certificate" {
+            $content = Get-Content $scriptPath -Raw
+            $content | Should -Match "wildcard-xebia-ms"
+            $content | Should -Match "WILDCARD_CERT_XEBIA_MS"
+        }
+
         It "Should use a temp file to write secret values (prevents exposure in process args)" {
             $content = Get-Content $scriptPath -Raw
             $content | Should -Match "GetTempFileName"

--- a/tests/powershell/Sync-KeyVaultSecrets.Tests.ps1
+++ b/tests/powershell/Sync-KeyVaultSecrets.Tests.ps1
@@ -153,7 +153,7 @@ Describe "Sync-KeyVaultSecrets" {
         It "Should write the GitHub Container Registry PAT" {
             $content = Get-Content $scriptPath -Raw
             $content | Should -Match "techhub-github-registry-token"
-            $content | Should -Match "GHCR_REGISTRY_TOKEN"
+            $content | Should -Match "GHCR_PAT"
         }
 
         It "Should write the wildcard-hub-ms TLS certificate" {


### PR DESCRIPTION
## Problem

The CD pipeline was failing on first deploy with:

`
ERROR: The Vault 'kv-techhub-prod' not found within subscription.
Write-Error: Sync-KeyVaultSecrets.ps1 failed: Failed to add IP ... to Key Vault 'kv-techhub-prod' firewall.
`

Sync-KeyVaultSecrets.ps1 was running **before** Bicep, but kv-techhub-prod is created **by** Bicep. On a completely fresh environment the vault doesn't exist yet.

## Solution

Split the deployment into two phases with a secret sync in between:

1. **Phase 1** — Deploy base infrastructure with deployApps=false (creates Key Vault, PostgreSQL, VNet, identity, Container Apps Environment — everything except the Container Apps themselves)
2. **Sync secrets** — Sync-KeyVaultSecrets.ps1 runs now that the vault exists
3. **Phase 2** — Deploy Container Apps (the registry token and app secrets are already in the vault)

This works on both fresh environments and normal updates.

## Changes

**infra/main.bicep**
- Added deployApps bool = true parameter — when alse, skips wildcardCerts, piApp, and webApp module deployments
- Added #disable-next-line BCP318 directives for conditional module output accesses

**scripts/Deploy-Infrastructure.ps1**
- Removed pre-Bicep secret sync (was failing on fresh environment)
- Deploy step is now two phases: deployApps=false first, then secret sync, then full deploy
