### PR TITLE
Use Az PowerShell for deployment progress visibility

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -144,6 +144,11 @@ fi
 echo "Installing PowerShell modules..."
 pwsh -Command 'Install-Module HtmlToMarkdown -AcceptLicense -Force'
 pwsh -Command 'Install-Module Pester -Force -SkipPublisherCheck -MinimumVersion "5.0.0" -Scope CurrentUser'
+# Az.Accounts + Az.Resources are the only Az sub-modules needed for Deploy-Infrastructure.ps1
+# (New-AzDeployment, Test-AzDeployment, Get-AzContext). Installing just these avoids pulling
+# the full Az bundle (~80 modules).
+pwsh -Command 'Install-Module Az.Accounts -Force -Scope CurrentUser'
+pwsh -Command 'Install-Module Az.Resources -Force -Scope CurrentUser'
 
 # ==================== PowerShell Profile ====================
 echo "Setting up PowerShell profile..."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -567,6 +567,7 @@ jobs:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          enable-AzPSSession: true
 
       - name: Deploy production infrastructure and application
         id: deploy

--- a/docs/network-architecture.md
+++ b/docs/network-architecture.md
@@ -8,17 +8,26 @@ endpoint.
 ## Topology
 
 ```text
-Admin IP (firewall allowlisted)
+Internet
     │
-    ▼
+    ├── Web frontend (ca-techhub-web-prod) — public ingress (external: true)
+    │       HTTPS on tech.hub.ms, tech.xebia.ms (wildcard TLS from kv-techhub-prod)
+    │
+    └── Admin IP (allowlisted for Key Vault + PostgreSQL)
+
 Prod VNet — vnet-techhub-prod (10.2.0.0/16) [rg-techhub-prod]
-    └── snet-container-apps (10.2.0.0/23) — Container Apps Environment (prod + PR previews)
+    └── snet-container-apps (10.2.0.0/23) — Container Apps Environment (internal: false)
+         │
+         ├── ca-techhub-web-prod   [external: true]  ← reachable from internet
+         │
+         ├── ca-techhub-api-prod   [external: false] ← internal only, NOT reachable from internet
+         │       (Web frontend calls API over the internal Container Apps environment network)
          │
          ├── Key Vault service endpoint (Microsoft.KeyVault)
          │       → Container Apps reach kv-techhub-prod over Microsoft backbone
          │
          ├── PostgreSQL firewall rule (10.2.0.0–10.2.1.255)
-         │       → Container Apps reach psql-techhub-prod over public internet
+         │       → Container Apps reach psql-techhub-prod over public internet (source IP in subnet)
          │
          └── AI Foundry — open public access, Entra token auth (Cognitive Services OpenAI User RBAC)
 ```
@@ -32,7 +41,24 @@ Prod VNet — vnet-techhub-prod (10.2.0.0/16) [rg-techhub-prod]
 There is a single subnet: `snet-container-apps` (`10.2.0.0/23`), delegated to
 `Microsoft.App/environments`. No private endpoints or hub-spoke peering.
 
-## IP Firewall Rules
+## Container Apps Ingress
+
+The Container Apps Environment (`cae-techhub-prod`) is deployed with `internal: false`, meaning
+it has a public IP. However, each Container App controls its own ingress independently.
+
+| App | Ingress | Reachable from internet | Notes |
+|-----|---------|------------------------|-------|
+| `ca-techhub-web-prod` | `external: true` | **Yes** | Custom domains (`tech.hub.ms`, `tech.xebia.ms`); wildcard TLS from Key Vault |
+| `ca-techhub-api-prod` | `external: false` | **No** | Internal only; the Web frontend calls the API over the internal Container Apps environment network |
+
+The API backend is intentionally not publicly accessible. No path to the API exists from the
+internet — not via the custom domains, not via the default Container Apps FQDN. The Web Blazor
+frontend calls the API exclusively over the internal environment network (server-side rendering
+and SSR API calls stay within the Container Apps environment).
+
+CORS policy is configured on the API app and restricts allowed origins to the configured
+`primaryHosts` (i.e. `tech.hub.ms`, `tech.xebia.ms`), so even if the API were made external,
+cross-origin browser requests from unexpected origins would be blocked.
 
 Admin access to Azure resources is controlled via per-resource IP firewall rules using the
 `ADMIN_IP_ADDRESSES` environment variable (supports multiple comma-separated IPs).

--- a/scripts/Deploy-Infrastructure.ps1
+++ b/scripts/Deploy-Infrastructure.ps1
@@ -116,14 +116,13 @@ Write-Host "===============================================================" -Fo
 
 Write-Step "Validating prerequisites"
 
-# Check Azure CLI login
-$account = az account show -o json 2>&1
-if ($LASTEXITCODE -ne 0) {
-    Write-Fail "Not logged in to Azure CLI. Run 'az login' first."
+# Check Azure PowerShell login
+$context = Get-AzContext
+if (-not $context) {
+    Write-Fail "Not logged in to Azure PowerShell. Run 'Connect-AzAccount' first."
     exit 1
 }
-$accountInfo = $account | ConvertFrom-Json
-Write-Ok "Azure CLI authenticated (subscription: $($accountInfo.name))"
+Write-Ok "Azure PowerShell authenticated (subscription: $($context.Subscription.Name))"
 
 # Check template files exist
 if (-not (Test-Path $templateFile)) {
@@ -206,12 +205,14 @@ Write-Step "Image tag: $ImageTag"
 if ($Mode -in @('validate', 'whatif', 'deploy')) {
     Write-Step "Validating Bicep template"
 
-    az deployment sub validate `
-        --location $Location `
-        --template-file $templateFile `
-        --parameters $paramsFile
+    $validationErrors = Test-AzDeployment `
+        -Location $Location `
+        -TemplateFile $templateFile `
+        -TemplateParameterFile $paramsFile `
+        -SkipTemplateParameterPrompt
 
-    if ($LASTEXITCODE -ne 0) {
+    if ($validationErrors) {
+        $validationErrors | ForEach-Object { Write-Fail $_.Message }
         Write-Fail "Template validation failed"
         exit 1
     }
@@ -222,13 +223,15 @@ if ($Mode -in @('validate', 'whatif', 'deploy')) {
 if ($Mode -eq 'whatif') {
     Write-Step "Running What-If analysis"
 
-    az deployment sub what-if `
-        --location $Location `
-        --template-file $templateFile `
-        --parameters $paramsFile
-
-    if ($LASTEXITCODE -ne 0) {
-        Write-Fail "What-If analysis failed"
+    try {
+        New-AzDeployment `
+            -Location $Location `
+            -TemplateFile $templateFile `
+            -TemplateParameterFile $paramsFile `
+            -SkipTemplateParameterPrompt `
+            -WhatIf
+    } catch {
+        Write-Fail "What-If analysis failed: $_"
         exit 1
     }
     Write-Ok "What-If analysis completed"
@@ -240,17 +243,23 @@ if ($Mode -eq 'deploy') {
     # Container Apps are skipped (deployApps=false) so the Key Vault exists before we write secrets.
     Write-Step "Phase 1: Deploying base infrastructure"
 
-    az deployment sub create `
-        --name "$deploymentName-infra" `
-        --location $Location `
-        --template-file $templateFile `
-        --parameters $paramsFile `
-        --parameters deployApps=false
-
-    if ($LASTEXITCODE -ne 0) {
-        Write-Fail "Phase 1 infrastructure deployment failed"
+    # New-AzDeployment -Verbose streams one line per resource as it completes, giving
+    # continuous progress output instead of the silent wait from az deployment sub create.
+    $VerbosePreference = 'Continue'
+    try {
+        New-AzDeployment `
+            -Name "$deploymentName-infra" `
+            -Location $Location `
+            -TemplateFile $templateFile `
+            -TemplateParameterFile $paramsFile `
+            -TemplateParameterObject @{ deployApps = $false } `
+            -SkipTemplateParameterPrompt
+    } catch {
+        $VerbosePreference = 'SilentlyContinue'
+        Write-Fail "Phase 1 infrastructure deployment failed: $_"
         exit 1
     }
+    $VerbosePreference = 'SilentlyContinue'
     Write-Ok "Base infrastructure deployed successfully"
 
     # Sync secrets now that the Key Vault exists.
@@ -273,16 +282,20 @@ if ($Mode -eq 'deploy') {
     # Phase 2: Container Apps — registry token + app secrets are now in the Key Vault.
     Write-Step "Phase 2: Deploying Container Apps"
 
-    az deployment sub create `
-        --name "$deploymentName-apps" `
-        --location $Location `
-        --template-file $templateFile `
-        --parameters $paramsFile
-
-    if ($LASTEXITCODE -ne 0) {
-        Write-Fail "Phase 2 Container Apps deployment failed"
+    $VerbosePreference = 'Continue'
+    try {
+        New-AzDeployment `
+            -Name "$deploymentName-apps" `
+            -Location $Location `
+            -TemplateFile $templateFile `
+            -TemplateParameterFile $paramsFile `
+            -SkipTemplateParameterPrompt
+    } catch {
+        $VerbosePreference = 'SilentlyContinue'
+        Write-Fail "Phase 2 Container Apps deployment failed: $_"
         exit 1
     }
+    $VerbosePreference = 'SilentlyContinue'
     Write-Ok "Container Apps deployed successfully"
 }
 

--- a/scripts/Deploy-Infrastructure.ps1
+++ b/scripts/Deploy-Infrastructure.ps1
@@ -117,7 +117,7 @@ Write-Host "===============================================================" -Fo
 Write-Step "Validating prerequisites"
 
 # Check Azure PowerShell login
-$context = Get-AzContext
+$context = Get-AzContext -ErrorAction SilentlyContinue
 if (-not $context) {
     Write-Fail "Not logged in to Azure PowerShell. Run 'Connect-AzAccount' first."
     exit 1
@@ -245,6 +245,7 @@ if ($Mode -eq 'deploy') {
 
     # New-AzDeployment -Verbose streams one line per resource as it completes, giving
     # continuous progress output instead of the silent wait from az deployment sub create.
+    $savedVerbose = $VerbosePreference
     $VerbosePreference = 'Continue'
     try {
         New-AzDeployment `
@@ -255,11 +256,11 @@ if ($Mode -eq 'deploy') {
             -TemplateParameterObject @{ deployApps = $false } `
             -SkipTemplateParameterPrompt
     } catch {
-        $VerbosePreference = 'SilentlyContinue'
         Write-Fail "Phase 1 infrastructure deployment failed: $_"
         exit 1
+    } finally {
+        $VerbosePreference = $savedVerbose
     }
-    $VerbosePreference = 'SilentlyContinue'
     Write-Ok "Base infrastructure deployed successfully"
 
     # Sync secrets now that the Key Vault exists.
@@ -282,6 +283,7 @@ if ($Mode -eq 'deploy') {
     # Phase 2: Container Apps — registry token + app secrets are now in the Key Vault.
     Write-Step "Phase 2: Deploying Container Apps"
 
+    $savedVerbose = $VerbosePreference
     $VerbosePreference = 'Continue'
     try {
         New-AzDeployment `
@@ -291,11 +293,11 @@ if ($Mode -eq 'deploy') {
             -TemplateParameterFile $paramsFile `
             -SkipTemplateParameterPrompt
     } catch {
-        $VerbosePreference = 'SilentlyContinue'
         Write-Fail "Phase 2 Container Apps deployment failed: $_"
         exit 1
+    } finally {
+        $VerbosePreference = $savedVerbose
     }
-    $VerbosePreference = 'SilentlyContinue'
     Write-Ok "Container Apps deployed successfully"
 }
 

--- a/src/TechHub.Core/AGENTS.md
+++ b/src/TechHub.Core/AGENTS.md
@@ -53,7 +53,7 @@ All methods async with `CancellationToken ct = default`. Return `IReadOnlyList<T
 
 ## Frontmatter Mapping
 
-📖 See [docs/content-schema.md](../../docs/content-schema.md#metadata-to-domain-model-mapping) for complete field definitions.
+📖 See [docs/content-schema.md](../../docs/content-schema.md#domain-model-mapping) for complete field definitions.
 
 Key mappings: `date` → `DateEpoch` (Unix timestamp, Europe/Brussels), `section_names` → `SectionNames` (array), `tags` → `Tags` (normalized lowercase), filename → `Slug`.
 

--- a/src/TechHub.Web/Components/ContentItemsGrid.razor.css
+++ b/src/TechHub.Web/Components/ContentItemsGrid.razor.css
@@ -122,7 +122,7 @@
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-6);
   background: transparent;
-  color: var(--color-text-link);
+  color: var(--color-purple-medium);
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-md);
   font-size: 0.95rem;
@@ -132,8 +132,8 @@
 }
 
 .load-more-btn:hover:not(:disabled) {
-  background: var(--color-bg-subtle);
-  border-color: var(--color-text-link);
+  background: var(--color-purple-bg-subtle);
+  border-color: var(--color-purple-medium);
 }
 
 .load-more-btn:disabled {

--- a/tests/TechHub.Api.Tests/Endpoints/AdminCustomPagesEndpointsTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/AdminCustomPagesEndpointsTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using TechHub.Core.Models.Admin;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Endpoints;
 

--- a/tests/TechHub.Api.Tests/Endpoints/AdminEndpointsTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/AdminEndpointsTests.cs
@@ -9,7 +9,6 @@ using TechHub.Core.Interfaces;
 using TechHub.Core.Models;
 using TechHub.Core.Models.Admin;
 using TechHub.Core.Models.ContentProcessing;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Endpoints;
 

--- a/tests/TechHub.Api.Tests/Endpoints/AdminGhcFeaturesEndpointsTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/AdminGhcFeaturesEndpointsTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using FluentAssertions;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Endpoints;
 

--- a/tests/TechHub.Api.Tests/Endpoints/AdminProcessUrlEndpointTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/AdminProcessUrlEndpointTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Endpoints;
 

--- a/tests/TechHub.Api.Tests/Endpoints/AuthorEndpointsTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/AuthorEndpointsTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using TechHub.Core.Models;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Endpoints;
 

--- a/tests/TechHub.Api.Tests/Endpoints/CustomPagesEndpointsTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/CustomPagesEndpointsTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using TechHub.Core.Models;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Endpoints;
 

--- a/tests/TechHub.Api.Tests/Endpoints/GhcFeaturesEndpointsTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/GhcFeaturesEndpointsTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using TechHub.Core.Models;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Endpoints;
 

--- a/tests/TechHub.Api.Tests/Endpoints/LegacyRedirectEndpointTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/LegacyRedirectEndpointTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using TechHub.Core.Models;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Endpoints;
 

--- a/tests/TechHub.Api.Tests/Endpoints/RssEndpointsTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/RssEndpointsTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Xml.Linq;
 using FluentAssertions;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Endpoints;
 
@@ -200,5 +199,4 @@ public class RssEndpointsTests : IClassFixture<TechHubIntegrationTestApiFactory>
             item.Element("description")?.Value.Should().NotBeNull();
         });
     }
-
 }

--- a/tests/TechHub.Api.Tests/Endpoints/SitemapEndpointsTests.cs
+++ b/tests/TechHub.Api.Tests/Endpoints/SitemapEndpointsTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Xml.Linq;
 using FluentAssertions;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Endpoints;
 

--- a/tests/TechHub.Api.Tests/HealthCheckTests.cs
+++ b/tests/TechHub.Api.Tests/HealthCheckTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using FluentAssertions;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests;
 

--- a/tests/TechHub.Api.Tests/Middleware/ExceptionHandlerMiddlewareTests.cs
+++ b/tests/TechHub.Api.Tests/Middleware/ExceptionHandlerMiddlewareTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using FluentAssertions;
-using TechHub.TestUtilities;
 
 namespace TechHub.Api.Tests.Middleware;
 

--- a/tests/TechHub.Api.Tests/TechHubApiFactory.cs
+++ b/tests/TechHub.Api.Tests/TechHubApiFactory.cs
@@ -10,7 +10,6 @@ using TechHub.Core.Interfaces;
 using TechHub.Infrastructure.Data;
 using TechHub.TestUtilities;
 using Testcontainers.PostgreSql;
-using Xunit;
 
 namespace TechHub.Api.Tests;
 

--- a/tests/TechHub.E2E.Tests/Web/LoadMoreButtonTests.cs
+++ b/tests/TechHub.E2E.Tests/Web/LoadMoreButtonTests.cs
@@ -142,7 +142,10 @@ public class LoadMoreButtonTests : PlaywrightTestBase
             // finished loading), we're done — no click needed.
             var isEnd = await Page.EvaluateAsync<bool>(
                 "() => document.querySelector('.end-of-content') !== null");
-            if (isEnd) break;
+            if (isEnd)
+            {
+                break;
+            }
 
             var countBefore = await Page.Locator(".card").CountAsync();
 
@@ -157,7 +160,11 @@ public class LoadMoreButtonTests : PlaywrightTestBase
                 // Already done? (count grew or end-of-content appeared since loop started)
                 var alreadyDone = await Page.EvaluateAsync<bool>(
                     $"() => document.querySelectorAll('.card').length > {countBefore} || document.querySelector('.end-of-content') !== null");
-                if (alreadyDone) { batchCompleted = true; break; }
+                if (alreadyDone)
+                {
+                    batchCompleted = true;
+                    break;
+                }
 
                 // Click only when the button is enabled (not mid-load, not removed yet)
                 var buttonEnabled = await Page.EvaluateAsync<bool>(

--- a/tests/TechHub.E2E.Tests/Web/SectionRoundupTests.cs
+++ b/tests/TechHub.E2E.Tests/Web/SectionRoundupTests.cs
@@ -1,7 +1,5 @@
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using FluentAssertions;
-using Microsoft.Playwright;
 using TechHub.E2E.Tests.Helpers;
 
 namespace TechHub.E2E.Tests.Web;

--- a/tests/TechHub.Infrastructure.Tests/DatabaseFixture.cs
+++ b/tests/TechHub.Infrastructure.Tests/DatabaseFixture.cs
@@ -6,7 +6,6 @@ using TechHub.Core.Logging;
 using TechHub.Infrastructure.Data;
 using TechHub.TestUtilities;
 using Testcontainers.PostgreSql;
-using Xunit;
 
 namespace TechHub.Infrastructure.Tests;
 

--- a/tests/TechHub.Infrastructure.Tests/Repositories/ContentRepositoryTests.cs
+++ b/tests/TechHub.Infrastructure.Tests/Repositories/ContentRepositoryTests.cs
@@ -7,7 +7,6 @@ using TechHub.Core.Configuration;
 using TechHub.Core.Interfaces;
 using TechHub.Core.Models;
 using TechHub.Infrastructure.Repositories;
-using TechHub.TestUtilities;
 using static TechHub.TestUtilities.TestDataConstants;
 
 namespace TechHub.Infrastructure.Tests.Repositories;

--- a/tests/TechHub.Web.Tests/Components/ContentItemCardTests.cs
+++ b/tests/TechHub.Web.Tests/Components/ContentItemCardTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using TechHub.Core.Models;
 using TechHub.TestUtilities.Builders;
 using TechHub.Web.Components;
-using TechHub.Web.Services;
 
 namespace TechHub.Web.Tests.Components;
 

--- a/tests/TechHub.Web.Tests/Components/Pages/SectionCollectionTests.cs
+++ b/tests/TechHub.Web.Tests/Components/Pages/SectionCollectionTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using TechHub.Core.Models;
 using TechHub.Web.Components;
 using TechHub.Web.Components.Pages;
-using TechHub.Web.Services;
 
 namespace TechHub.Web.Tests.Components.Pages;
 


### PR DESCRIPTION
Use Az PowerShell for deployment progress visibility

CI logs were completely silent during the 10-15 minute Azure deployment phases, making it impossible to see what was happening or diagnose slow/failing deployments. Switching to `New-AzDeployment -Verbose` makes each provisioned resource appear in the logs as it completes.

## Changes

**`scripts/Deploy-Infrastructure.ps1`** - full Az PowerShell migration:
- `az account show` -> `Get-AzContext` (auth check)
- `az deployment sub validate` -> `Test-AzDeployment`
- `az deployment sub what-if` -> `New-AzDeployment -WhatIf`
- `az deployment sub create` -> `New-AzDeployment -Verbose` (Phase 1 + Phase 2)
- `$VerbosePreference = 'Continue'` around deploy calls to stream per-resource lines to stdout

**`.github/workflows/cd.yml`** - added `enable-AzPSSession: true` to `azure/login` so Az PS module is authenticated in CI.

**`.devcontainer/post-create.sh`** - installs `Az.Accounts` + `Az.Resources` modules so local deployments work without installing the full Az bundle (~80 modules).

**`docs/network-architecture.md`** - added Container Apps Ingress section documenting that the API (`ca-techhub-api-prod`) has `external: false` (not reachable from internet) and the Web (`ca-techhub-web-prod`) has `external: true`.

**Misc cleanup:** load-more button colors to purple design tokens, removed stale `using TechHub.TestUtilities` imports from API tests, E2E test brace formatting, AGENTS.md anchor fix.
