### PR TITLE
Fix production CD: correct PostgreSQL firewall for Container Apps SNAT + prevent cert deployment hang

### DIFF
--- a/docs/cost-reduction-plan.md
+++ b/docs/cost-reduction-plan.md
@@ -140,7 +140,7 @@ No ACR — images on ghcr.io (private packages, registry credentials in Key Vaul
 - Update `sharedKeyVaultUri` → `keyVaultUri` (local KV, same deployment)
 - Update `wildcardCerts` module: KV is now in same RG (remove `sharedResourceGroupName`)
 - Update `actionGroupId`: now from local `actionGroup.outputs.actionGroupId`
-- Pass `containerAppsStartIp` / `containerAppsEndIp` to `postgres` module for subnet firewall rule
+- Pass `containerAppsStaticIp: containerAppsEnv.outputs.staticIp` to `postgres` module for outbound SNAT firewall rule
 - Pass `containerAppsSubnetId` to `keyVault` module for VNet service endpoint
 
 ---
@@ -192,24 +192,26 @@ No ACR — images on ghcr.io (private packages, registry credentials in Key Vaul
 
 **Add params:**
 
-- `containerAppsStartIp string = ''` — e.g. `'10.2.0.0'`
-- `containerAppsEndIp string = ''` — e.g. `'10.2.1.255'`
+- `containerAppsStaticIp string = ''` — e.g. `'135.116.37.183'` (Container Apps Environment static IP)
 
 **Add firewall rule:**
 
 ```bicep
-resource containerAppsFirewallRule 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = if (!empty(containerAppsStartIp)) {
+resource containerAppsStaticIpFirewallRule 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = if (!empty(containerAppsStaticIp)) {
   parent: postgresServer
-  name: 'allow-container-apps-subnet'
+  name: 'allow-container-apps-static-ip'
   properties: {
-    startIpAddress: containerAppsStartIp
-    endIpAddress: containerAppsEndIp
+    startIpAddress: containerAppsStaticIp
+    endIpAddress: containerAppsStaticIp
   }
 }
 ```
 
-Use explicit start/end IP params rather than CIDR parsing — Bicep has no native CIDR-to-range conversion. For `10.2.0.0/23`: start = `10.2.0.0`, end = `10.2.1.255`.
-
+> **SNAT note:** VNet-integrated Container Apps without a NAT gateway use the Container Apps
+> Environment's **static IP** (load balancer SNAT) as the outbound source IP when connecting
+> to public internet endpoints like PostgreSQL. The VNet subnet range (10.2.0.0/23) is NOT
+> the source IP seen by PostgreSQL — it is SNAT'd to the load balancer frontend IP. The static
+> IP is obtained from `containerAppsEnv.outputs.staticIp` and passed to the postgres module.
 > **Security note:** This grants network access to all Container Apps in the environment (including PR previews). This is acceptable because PR previews use their own PITR-cloned database — they never have credentials for `psql-techhub-prod`. The firewall rule provides network-level access, but authentication still requires the correct connection string (stored only in Key Vault secrets accessible to the prod Container App).
 
 ---

--- a/docs/network-architecture.md
+++ b/docs/network-architecture.md
@@ -26,8 +26,9 @@ Prod VNet — vnet-techhub-prod (10.2.0.0/16) [rg-techhub-prod]
          ├── Key Vault service endpoint (Microsoft.KeyVault)
          │       → Container Apps reach kv-techhub-prod over Microsoft backbone
          │
-         ├── PostgreSQL firewall rule (10.2.0.0–10.2.1.255)
-         │       → Container Apps reach psql-techhub-prod over public internet (source IP in subnet)
+         ├── PostgreSQL firewall rule (Container Apps static IP / SNAT source)
+         │       → Container Apps reach psql-techhub-prod over public internet
+         │       → Source IP is the CAE static IP (load balancer SNAT), NOT the VNet subnet range
          │
          └── AI Foundry — open public access, Entra token auth (Cognitive Services OpenAI User RBAC)
 ```
@@ -66,7 +67,7 @@ Admin access to Azure resources is controlled via per-resource IP firewall rules
 | Resource | Firewall Mechanism | Access |
 |----------|-------------------|--------|
 | Key Vault | `networkAcls.ipRules` + VNet service endpoint | Admin IPs + Container Apps subnet; default deny |
-| PostgreSQL | Per-IP/range firewall rules | Admin IPs + Container Apps subnet (10.2.0.0–10.2.1.255); default deny |
+| PostgreSQL | Per-IP/range firewall rules | Admin IPs + Container Apps Environment static IP (SNAT outbound); default deny |
 | Log Analytics | Public ingestion + query enabled | RBAC-protected |
 | App Insights | Public ingestion + query enabled | RBAC-protected; browser JS SDK over public internet |
 | AI Foundry | Public access open | Entra token (Cognitive Services OpenAI User RBAC); no IP restriction needed |
@@ -115,9 +116,12 @@ created via PITR from the production backup — both in `rg-techhub-prod`.
 
 - **Production**: `psql-techhub-prod` — permanent, public access with firewall rules; both password auth (for admin/emergency use) and Entra ID auth enabled
 - **PR environments**: `psql-techhub-pr-{N}` — ephemeral, created via Point-in-Time Restore; Entra-only auth
-- **Public access**: Enabled with firewall rules for admin IPs and Container Apps subnet
-- **Firewall**: Admin IP rules + Container Apps subnet range (10.2.0.0–10.2.1.255)
-- **Container Apps** reach PostgreSQL over the public internet (source IP is in the CA subnet range)
+- **Public access**: Enabled with firewall rules for admin IPs and the Container Apps Environment static IP
+- **Firewall**: Admin IP rules + Container Apps Environment static outbound IP (SNAT)
+- **Container Apps** reach PostgreSQL over the public internet; the source IP is the
+  Container Apps Environment's **static IP** (load balancer SNAT) — NOT the VNet subnet range.
+  VNet-integrated Container Apps without a NAT gateway use the environment's load balancer
+  frontend IP for outbound SNAT to public endpoints.
 - **Admin** reaches PostgreSQL via IP-allowlisted public access
 
 > **Authentication**: The `id-techhub-prod` user-assigned managed identity is registered as the

--- a/infra/applications.bicep
+++ b/infra/applications.bicep
@@ -146,26 +146,28 @@ var effectiveAppInsightsConnStr = appInsightsConnectionString == '@existing' ? a
 // Wildcard certificates
 // ============================================================================
 
-module wildcardCerts './modules/wildcardCertificates.bicep' = if (!empty(wildcardCertNames)) {
-  scope: resourceGroup
-  name: 'wildcardCerts-${deploymentSuffix}'
-  params: {
-    location: location
-    containerAppsEnvironmentName: containerAppsEnvName
-    keyVaultName: keyVaultName
-    wildcardCertNames: wildcardCertNames
-    identityId: managedIdentity.id
-    identityPrincipalId: managedIdentity.properties.principalId
-    deploymentSuffix: deploymentSuffix
-  }
-}
+// Reference existing wildcard certificates via `existing` — do NOT re-deploy them.
+//
+// Background: re-deploying Microsoft.App/managedEnvironments/certificates via Bicep on every
+// CD run triggers an idempotent ARM PUT on the Azure Container Apps cert provider. When the
+// cert already exists the provider starts an async re-import operation that never signals
+// completion, causing ARM to poll indefinitely and the deployment to hang.
+//
+// Certificates are created once (initial environment setup) and renewed via
+// infra/modules/wildcardCertificates.bicep run separately after cert rotation.
+// See docs/wildcard-certificates.md for the renewal process.
+var certEntries = items(wildcardCertNames)
+resource existingCerts 'Microsoft.App/managedEnvironments/certificates@2025-07-01' existing = [for entry in certEntries: {
+  parent: containerAppsEnvResource
+  name: 'wildcard-${replace(entry.key, '.', '-')}'
+}]
 
-// Build a map of base domain → certificate resource ID for the web module
-#disable-next-line BCP318
-var _certDomains = !empty(wildcardCertNames) ? wildcardCerts.outputs.certDomains : []
-#disable-next-line BCP318
-var _certIds = !empty(wildcardCertNames) ? wildcardCerts.outputs.certIds : []
-var wildcardCertIds = toObject(_certDomains, domain => domain, domain => _certIds[indexOf(_certDomains, domain)])
+// Build cert ID lookup: { 'hub.ms': '/subscriptions/.../certificates/wildcard-hub-ms', ... }
+var wildcardCertIdPairs = [for (entry, i) in certEntries: {
+  key: entry.key
+  value: existingCerts[i].id
+}]
+var wildcardCertIds = !empty(certEntries) ? toObject(wildcardCertIdPairs, item => item.key, item => item.value) : {}
 
 // ============================================================================
 // Container Apps

--- a/infra/infrastructure.bicep
+++ b/infra/infrastructure.bicep
@@ -30,12 +30,6 @@ param addressSpacePrefix string = '10.2.0.0/16'
 @description('Container Apps subnet prefix')
 param containerAppsSubnetPrefix string = '10.2.0.0/23'
 
-@description('First IP of the Container Apps subnet (for PostgreSQL firewall rule — Bicep cannot parse CIDR)')
-param containerAppsSubnetStartIp string = '10.2.0.0'
-
-@description('Last IP of the Container Apps subnet (for PostgreSQL firewall rule — Bicep cannot parse CIDR)')
-param containerAppsSubnetEndIp string = '10.2.1.255'
-
 @description('Primary host names for the web app. Used for Application Insights availability tests.')
 param primaryHosts string[] = []
 
@@ -242,8 +236,10 @@ module postgres './modules/postgres.bicep' = {
     backupRetentionDays: 21
     geoRedundantBackup: true
     adminIpAddresses: adminIpList
-    containerAppsSubnetStartIp: containerAppsSubnetStartIp
-    containerAppsSubnetEndIp: containerAppsSubnetEndIp
+    // Container Apps uses Azure SNAT with the environment's static IP as the outbound source
+    // IP when connecting to PostgreSQL's public endpoint. The VNet subnet IPs (10.x.x.x) are
+    // NOT the source IP seen by PostgreSQL — they are SNAT'd to the load balancer frontend IP.
+    containerAppsStaticIp: containerAppsEnv.outputs.staticIp
     entraAdminObjectId: identity.outputs.identityPrincipalId
     entraAdminName: prodIdentityName
     tags: prodTags

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -60,3 +60,7 @@ resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-pr
 
 output environmentId string = containerAppsEnvironment.id
 output defaultDomain string = containerAppsEnvironment.properties.defaultDomain
+// The static IP is the load balancer frontend IP used for both inbound traffic and outbound
+// SNAT when containers connect to public endpoints (e.g. PostgreSQL public endpoint).
+// Add this IP to any firewall that Container Apps must reach over the public internet.
+output staticIp string = containerAppsEnvironment.properties.staticIp

--- a/infra/modules/postgres.bicep
+++ b/infra/modules/postgres.bicep
@@ -42,11 +42,8 @@ param geoRedundantBackup bool = false
 @description('Admin IP addresses for firewall rules (optional — leave empty to keep public access disabled)')
 param adminIpAddresses string[] = []
 
-@description('First IP of the Container Apps subnet (for firewall rule allowing Container Apps to reach PostgreSQL). Leave empty to skip.')
-param containerAppsSubnetStartIp string = ''
-
-@description('Last IP of the Container Apps subnet (for firewall rule allowing Container Apps to reach PostgreSQL). Leave empty to skip.')
-param containerAppsSubnetEndIp string = ''
+@description('Static outbound IP of the Container Apps Environment (load balancer SNAT IP). Container Apps uses this IP when connecting to PostgreSQL public endpoint. Leave empty to skip.')
+param containerAppsStaticIp string = ''
 
 @description('Entra (AAD) object ID of the principal to register as the Active Directory administrator. Leave empty to skip Entra admin setup.')
 param entraAdminObjectId string = ''
@@ -99,7 +96,7 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' =
       startMinute: 0
     }
     network: {
-      publicNetworkAccess: (!empty(adminIpAddresses) || !empty(containerAppsSubnetStartIp)) ? 'Enabled' : 'Disabled'
+      publicNetworkAccess: (!empty(adminIpAddresses) || !empty(containerAppsStaticIp)) ? 'Enabled' : 'Disabled'
     }
   }
 }
@@ -114,14 +111,16 @@ resource adminFirewallRules 'Microsoft.DBforPostgreSQL/flexibleServers/firewallR
   }
 }]
 
-// Firewall rule: allow Container Apps subnet IP range so Container Apps can reach PostgreSQL
-// without a private endpoint. Uses explicit start/end IPs because Bicep cannot parse CIDR.
-resource containerAppsSubnetFirewallRule 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = if (!empty(containerAppsSubnetStartIp) && !empty(containerAppsSubnetEndIp)) {
+// Firewall rule: allow the Container Apps Environment's static outbound IP.
+// VNet-integrated Container Apps use Azure SNAT (load balancer frontend IP) for outbound
+// connections to public endpoints. The VNet subnet IP range (10.x.x.x) is NOT the source IP
+// — it is SNAT'd to the Container Apps Environment's staticIp before leaving Azure.
+resource containerAppsStaticIpFirewallRule 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = if (!empty(containerAppsStaticIp)) {
   parent: postgresServer
-  name: 'allow-container-apps-subnet'
+  name: 'allow-container-apps-static-ip'
   properties: {
-    startIpAddress: containerAppsSubnetStartIp
-    endIpAddress: containerAppsSubnetEndIp
+    startIpAddress: containerAppsStaticIp
+    endIpAddress: containerAppsStaticIp
   }
 }
 
@@ -140,7 +139,7 @@ resource entraAdmin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@20
     principalType: 'ServicePrincipal'
     tenantId: subscription().tenantId
   }
-  dependsOn: [adminFirewallRules, containerAppsSubnetFirewallRule]
+  dependsOn: [adminFirewallRules, containerAppsStaticIpFirewallRule]
 }
 
 // Database

--- a/infra/parameters/prod-infrastructure.bicepparam
+++ b/infra/parameters/prod-infrastructure.bicepparam
@@ -9,11 +9,6 @@ param containerAppsEnvName = 'cae-techhub-prod'
 param vnetName = 'vnet-techhub-prod'
 param addressSpacePrefix = '10.2.0.0/16'
 param containerAppsSubnetPrefix = '10.2.0.0/23'
-// Container Apps subnet IP range for PostgreSQL firewall rule (Bicep cannot parse CIDR).
-// These must match containerAppsSubnetPrefix = '10.2.0.0/23'. Update all three if the subnet changes.
-// Also update the matching constants in scripts/Deploy-PrPreview.ps1 if the subnet changes.
-param containerAppsSubnetStartIp = '10.2.0.0'
-param containerAppsSubnetEndIp = '10.2.1.255'
 // Availability tests — same hosts as the production web app
 param primaryHosts = ['tech.hub.ms', 'tech.xebia.ms']
 // PostgreSQL configuration

--- a/scripts/Deploy-PrPreview.ps1
+++ b/scripts/Deploy-PrPreview.ps1
@@ -79,11 +79,10 @@ $prodIdentityName = 'id-techhub-prod'
 # Production server (source for PITR database clone)
 $prodPostgresServer = 'psql-techhub-prod'
 
-# Container Apps subnet range (used for PostgreSQL firewall rule).
-# These must match the containerAppsSubnetStartIp/EndIp values in infra/parameters/prod-infrastructure.bicepparam.
-# Update both places if the Container Apps subnet CIDR ever changes.
-$containerAppsSubnetStartIp = '10.2.0.0'
-$containerAppsSubnetEndIp = '10.2.1.255'
+# Container Apps subnet range (no longer used — see containerAppsStaticIp below).
+# Container Apps uses Azure SNAT (load balancer static IP) not the VNet subnet IPs as the
+# outbound source when connecting to PostgreSQL. The static IP is fetched dynamically from
+# the Container Apps environment at deploy time.
 
 # PR-specific resource names
 $prPostgresServer = "psql-techhub-pr-$PrNumber"
@@ -412,8 +411,21 @@ else {
 
 # Add firewall rules for the PR PostgreSQL server.
 # Admin IPs: allow explicit admin access.
-# Container Apps subnet: allow all Container Apps in the prod environment to reach the PR database.
+# Container Apps static IP: the prod environment's load balancer SNAT IP — used as the source
+# IP for all outbound connections from Container Apps to PostgreSQL's public endpoint.
 Write-Step "Configuring PostgreSQL firewall rules for $prPostgresServer"
+
+# Fetch the Container Apps Environment's static outbound IP.
+# This is the SNAT source IP seen by PostgreSQL, not the VNet subnet IP range (10.x.x.x).
+$containerAppsStaticIp = az containerapp env show `
+    --name $prodEnvName `
+    --resource-group $prodRG `
+    --query properties.staticIp -o tsv 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($containerAppsStaticIp)) {
+    Write-Fail "Could not retrieve Container Apps Environment static IP"
+    exit 1
+}
+Write-Ok "Container Apps static IP: $containerAppsStaticIp"
 
 # Parse admin IPs from env var
 $adminIps = @($env:ADMIN_IP_ADDRESSES -split ',' | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
@@ -454,49 +466,66 @@ foreach ($ip in $adminIps) {
     $ruleIndex++
 }
 
-# Container Apps subnet rule (idempotent)
-$containerAppsSubnetRuleName = 'allow-container-apps-subnet'
-$existingContainerAppsSubnetRuleJson = az postgres flexible-server firewall-rule list `
+# Container Apps static IP rule (idempotent)
+$containerAppsStaticIpRuleName = 'allow-container-apps-static-ip'
+
+# Clean up any old subnet-range rule from before the SNAT fix (safe to delete, it was ineffective)
+$oldSubnetRuleName = 'allow-container-apps-subnet'
+$oldSubnetRuleJson = az postgres flexible-server firewall-rule list `
     --resource-group $prodRG `
     --name $prPostgresServer `
-    --query "[?name=='$containerAppsSubnetRuleName'] | [0]" `
+    --query "[?name=='$oldSubnetRuleName'] | [0]" `
     --output json 2>$null
-$existingContainerAppsSubnetRule = $null
-if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($existingContainerAppsSubnetRuleJson) -and $existingContainerAppsSubnetRuleJson -ne 'null') {
-    $existingContainerAppsSubnetRule = $existingContainerAppsSubnetRuleJson | ConvertFrom-Json
+if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($oldSubnetRuleJson) -and $oldSubnetRuleJson -ne 'null') {
+    Write-Detail "Removing old (ineffective) Container Apps subnet firewall rule..."
+    az postgres flexible-server firewall-rule delete `
+        --resource-group $prodRG `
+        --name $prPostgresServer `
+        --rule-name $oldSubnetRuleName `
+        --yes 2>$null | Out-Null
 }
 
-if ($existingContainerAppsSubnetRule -and
-    $existingContainerAppsSubnetRule.startIpAddress -eq $containerAppsSubnetStartIp -and
-    $existingContainerAppsSubnetRule.endIpAddress -eq $containerAppsSubnetEndIp) {
-    Write-Ok "Container Apps subnet firewall rule already configured"
+$existingContainerAppsStaticIpRuleJson = az postgres flexible-server firewall-rule list `
+    --resource-group $prodRG `
+    --name $prPostgresServer `
+    --query "[?name=='$containerAppsStaticIpRuleName'] | [0]" `
+    --output json 2>$null
+$existingContainerAppsStaticIpRule = $null
+if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($existingContainerAppsStaticIpRuleJson) -and $existingContainerAppsStaticIpRuleJson -ne 'null') {
+    $existingContainerAppsStaticIpRule = $existingContainerAppsStaticIpRuleJson | ConvertFrom-Json
+}
+
+if ($existingContainerAppsStaticIpRule -and
+    $existingContainerAppsStaticIpRule.startIpAddress -eq $containerAppsStaticIp -and
+    $existingContainerAppsStaticIpRule.endIpAddress -eq $containerAppsStaticIp) {
+    Write-Ok "Container Apps static IP firewall rule already configured"
 }
 else {
-    if ($existingContainerAppsSubnetRule) {
-        Write-Detail "Replacing stale Container Apps subnet firewall rule..."
+    if ($existingContainerAppsStaticIpRule) {
+        Write-Detail "Replacing stale Container Apps static IP firewall rule..."
         az postgres flexible-server firewall-rule delete `
             --resource-group $prodRG `
             --name $prPostgresServer `
-            --rule-name $containerAppsSubnetRuleName `
+            --rule-name $containerAppsStaticIpRuleName `
             --yes 2>$null | Out-Null
         if ($LASTEXITCODE -ne 0) {
-            Write-Fail "Failed to remove existing Container Apps subnet firewall rule"
+            Write-Fail "Failed to remove existing Container Apps static IP firewall rule"
             exit 1
         }
     }
 
-    Write-Detail "Adding Container Apps subnet firewall rule ($containerAppsSubnetStartIp - $containerAppsSubnetEndIp)..."
+    Write-Detail "Adding Container Apps static IP firewall rule ($containerAppsStaticIp)..."
     az postgres flexible-server firewall-rule create `
         --resource-group $prodRG `
         --name $prPostgresServer `
-        --rule-name $containerAppsSubnetRuleName `
-        --start-ip-address $containerAppsSubnetStartIp `
-        --end-ip-address $containerAppsSubnetEndIp
+        --rule-name $containerAppsStaticIpRuleName `
+        --start-ip-address $containerAppsStaticIp `
+        --end-ip-address $containerAppsStaticIp
     if ($LASTEXITCODE -ne 0) {
-        Write-Fail "Failed to add Container Apps subnet firewall rule"
+        Write-Fail "Failed to add Container Apps static IP firewall rule"
         exit 1
     }
-    Write-Ok "Container Apps subnet firewall rule added"
+    Write-Ok "Container Apps static IP firewall rule added"
 }
 
 # ============================================================================

--- a/scripts/Deploy-PrPreview.ps1
+++ b/scripts/Deploy-PrPreview.ps1
@@ -420,9 +420,15 @@ Write-Step "Configuring PostgreSQL firewall rules for $prPostgresServer"
 $containerAppsStaticIp = az containerapp env show `
     --name $prodEnvName `
     --resource-group $prodRG `
-    --query properties.staticIp -o tsv 2>$null
-if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($containerAppsStaticIp)) {
-    Write-Fail "Could not retrieve Container Apps Environment static IP"
+    --query properties.staticIp -o tsv 2>&1
+if ($LASTEXITCODE -ne 0) {
+    $containerAppsStaticIpError = ($containerAppsStaticIp | Out-String).Trim()
+    Write-Fail "Could not retrieve Container Apps Environment static IP for env '$prodEnvName' in resource group '$prodRG'. Azure CLI error: $containerAppsStaticIpError"
+    exit 1
+}
+$containerAppsStaticIp = ($containerAppsStaticIp | Out-String).Trim()
+if ([string]::IsNullOrWhiteSpace($containerAppsStaticIp)) {
+    Write-Fail "Could not retrieve Container Apps Environment static IP for env '$prodEnvName' in resource group '$prodRG': the Azure CLI command returned an empty value."
     exit 1
 }
 Write-Ok "Container Apps static IP: $containerAppsStaticIp"


### PR DESCRIPTION
Fix production CD: correct PostgreSQL firewall for Container Apps SNAT + prevent cert deployment hang

## Problem

The production CD pipeline was hanging for 55+ minutes on every run due to two independent bugs:

1. **PostgreSQL TCP connection timeouts** — The API could not connect to the database on startup, causing `ActivationFailed` errors. The PostgreSQL firewall rule `allow-container-apps-subnet` allowed `10.2.0.0–10.2.1.255` (VNet subnet IPs), but VNet-integrated Container Apps use Azure SNAT — outbound connections to public endpoints use the Container Apps Environment's **load balancer frontend IP** (`135.116.37.183`), not the VNet IPs. The firewall rule never matched.

2. **Wildcard certificate ARM polling hang** — `applications.bicep` re-deployed existing wildcard certificates via `wildcardCertificates.bicep` on every CD run. The Azure Container Apps certificate ARM provider starts an async re-import operation when a cert PUT targets an already-existing cert, but the operation never signals completion. ARM polls indefinitely, hanging the entire deployment.

## Solution

- **Firewall**: Expose the Container Apps Environment's `staticIp` (load balancer SNAT IP) as a Bicep output and use it as the sole PostgreSQL firewall rule. Infrastructure phase now automatically derives the correct IP from the environment, creating an explicit Bicep dependency.

- **Certificates**: Replace the cert module deployment in `applications.bicep` with `existing` resource references. Certificates are created once during initial environment setup and renewed separately after rotation. The `existing` refs give the app deployment the cert IDs it needs without triggering ARM re-import.

## Changes

| File | Change |
|------|--------|
| `infra/modules/containerApps.bicep` | Added `staticIp` output (load balancer SNAT IP) |
| `infra/modules/postgres.bicep` | Replaced subnet IP range params/rule with `containerAppsStaticIp` single-IP rule |
| `infra/infrastructure.bicep` | Wired `staticIp` output to postgres module; removed subnet IP params |
| `infra/parameters/prod-infrastructure.bicepparam` | Removed incorrect subnet IP param values |
| `infra/applications.bicep` | Replaced cert module deployment with `existing` resource references |
| `scripts/Deploy-PrPreview.ps1` | Applied same SNAT static IP fix for PR preview PostgreSQL servers |
| `docs/network-architecture.md` | Corrected SNAT documentation |
| `docs/cost-reduction-plan.md` | Updated postgres module param references |
