### PR TITLE
Fix: NAT Gateway for stable Container Apps outbound IP + AZURE_CLIENT_ID for managed identity auth

### DIFF
--- a/infra/applications.bicep
+++ b/infra/applications.bicep
@@ -184,6 +184,7 @@ module apiApp './modules/api.bicep' = {
     githubRegistryUsername: githubRegistryUsername
     githubRegistryAuthUsername: githubRegistryAuthUsername
     identityId: managedIdentity.id
+    identityClientId: managedIdentity.properties.clientId
     imageTag: apiImageTag
     appInsightsConnectionString: effectiveAppInsightsConnStr
     keyVaultUri: keyVaultUri

--- a/infra/infrastructure.bicep
+++ b/infra/infrastructure.bicep
@@ -236,10 +236,9 @@ module postgres './modules/postgres.bicep' = {
     backupRetentionDays: 21
     geoRedundantBackup: true
     adminIpAddresses: adminIpList
-    // Container Apps uses Azure SNAT with the environment's static IP as the outbound source
-    // IP when connecting to PostgreSQL's public endpoint. The VNet subnet IPs (10.x.x.x) are
-    // NOT the source IP seen by PostgreSQL — they are SNAT'd to the load balancer frontend IP.
-    containerAppsStaticIp: containerAppsEnv.outputs.staticIp
+    // Container Apps routes outbound traffic through the NAT Gateway, which has a single
+    // stable public IP. PostgreSQL's firewall must allowlist this IP.
+    containerAppsNatGatewayIp: network.outputs.natGatewayPublicIp
     entraAdminObjectId: identity.outputs.identityPrincipalId
     entraAdminName: prodIdentityName
     tags: prodTags

--- a/infra/modules/api.bicep
+++ b/infra/modules/api.bicep
@@ -11,6 +11,9 @@ param githubRegistryAuthUsername string = githubRegistryUsername
 @description('User-assigned managed identity resource ID (used to access Key Vault secrets)')
 param identityId string
 
+@description('Client ID of the user-assigned managed identity. Required for DefaultAzureCredential to select the correct identity when multiple are available.')
+param identityClientId string
+
 param imageTag string
 param appInsightsConnectionString string
 
@@ -80,6 +83,13 @@ var staticEnvVars = [
   {
     name: 'OTEL_SERVICE_NAME'
     value: 'techhub-api'
+  }
+  {
+    // Required for DefaultAzureCredential / ManagedIdentityCredential to select the correct
+    // user-assigned managed identity. Without this, IMDS returns HTTP 400 when multiple
+    // identities exist or when the managed identity endpoint requires an explicit client_id.
+    name: 'AZURE_CLIENT_ID'
+    value: identityClientId
   }
   {
     name: 'Database__Provider'

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -60,7 +60,3 @@ resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-pr
 
 output environmentId string = containerAppsEnvironment.id
 output defaultDomain string = containerAppsEnvironment.properties.defaultDomain
-// The static IP is the load balancer frontend IP used for both inbound traffic and outbound
-// SNAT when containers connect to public endpoints (e.g. PostgreSQL public endpoint).
-// Add this IP to any firewall that Container Apps must reach over the public internet.
-output staticIp string = containerAppsEnvironment.properties.staticIp

--- a/infra/modules/network.bicep
+++ b/infra/modules/network.bicep
@@ -16,6 +16,15 @@ param containerAppsSubnetPrefix string = '10.0.0.0/23'
 @description('Tags applied to networking resources')
 param tags object = {}
 
+@description('''
+Availability zones for the NAT Gateway and its public IP.
+  - ['1'] (default) — pin to a single zone; use when the existing resource was created zonal
+    (zones are immutable on public IPs — must match the existing resource to avoid deployment errors).
+  - [] — non-zonal / regional; works in regions without availability zone support.
+  Pass an explicit value to override the default for new or zone-redundant deployments.
+''')
+param natGatewayZones array = ['1']
+
 // NAT Gateway public IP — provides a stable, predictable outbound IP for Container Apps.
 // Without a NAT Gateway, Container Apps uses a large shared pool of ephemeral Azure
 // infrastructure SNAT IPs (~150+ IPs) that change unpredictably and cannot be allowlisted
@@ -28,7 +37,7 @@ resource natGatewayPublicIp 'Microsoft.Network/publicIPAddresses@2025-01-01' = {
     name: 'Standard'
     tier: 'Regional'
   }
-  zones: ['1']
+  zones: natGatewayZones
   properties: {
     publicIPAllocationMethod: 'Static'
     publicIPAddressVersion: 'IPv4'
@@ -43,7 +52,7 @@ resource natGateway 'Microsoft.Network/natGateways@2025-01-01' = {
   sku: {
     name: 'Standard'
   }
-  zones: ['1']
+  zones: natGatewayZones
   properties: {
     idleTimeoutInMinutes: 10
     publicIpAddresses: [

--- a/infra/modules/network.bicep
+++ b/infra/modules/network.bicep
@@ -16,6 +16,44 @@ param containerAppsSubnetPrefix string = '10.0.0.0/23'
 @description('Tags applied to networking resources')
 param tags object = {}
 
+// NAT Gateway public IP — provides a stable, predictable outbound IP for Container Apps.
+// Without a NAT Gateway, Container Apps uses a large shared pool of ephemeral Azure
+// infrastructure SNAT IPs (~150+ IPs) that change unpredictably and cannot be allowlisted
+// in PostgreSQL firewall rules. The NAT Gateway gives a single fixed outbound IP.
+resource natGatewayPublicIp 'Microsoft.Network/publicIPAddresses@2025-01-01' = {
+  name: replace(vnetName, 'vnet-', 'pip-nat-')
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
+  zones: ['1']
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    publicIPAddressVersion: 'IPv4'
+  }
+}
+
+// NAT Gateway — routes all outbound Container Apps traffic through the stable public IP above.
+resource natGateway 'Microsoft.Network/natGateways@2025-01-01' = {
+  name: replace(vnetName, 'vnet-', 'natgw-')
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard'
+  }
+  zones: ['1']
+  properties: {
+    idleTimeoutInMinutes: 10
+    publicIpAddresses: [
+      {
+        id: natGatewayPublicIp.id
+      }
+    ]
+  }
+}
+
 // Virtual Network with a single Container Apps subnet.
 // Key Vault uses a VNet service endpoint on this subnet (no private endpoint needed).
 resource vnet 'Microsoft.Network/virtualNetworks@2025-01-01' = {
@@ -34,6 +72,9 @@ resource vnet 'Microsoft.Network/virtualNetworks@2025-01-01' = {
         name: containerAppsSubnetName
         properties: {
           addressPrefix: containerAppsSubnetPrefix
+          natGateway: {
+            id: natGateway.id
+          }
           delegations: [
             {
               name: 'Microsoft.App.environments'
@@ -62,3 +103,6 @@ resource vnet 'Microsoft.Network/virtualNetworks@2025-01-01' = {
 output vnetId string = vnet.id
 output vnetName string = vnet.name
 output containerAppsSubnetId string = vnet.properties.subnets[0].id
+// Public IP used by the NAT Gateway — must be allowlisted in PostgreSQL firewall rules
+// so Container Apps can reach PostgreSQL over the public internet.
+output natGatewayPublicIp string = natGatewayPublicIp.properties.ipAddress

--- a/infra/modules/postgres.bicep
+++ b/infra/modules/postgres.bicep
@@ -42,8 +42,8 @@ param geoRedundantBackup bool = false
 @description('Admin IP addresses for firewall rules (optional — leave empty to keep public access disabled)')
 param adminIpAddresses string[] = []
 
-@description('Static outbound IP of the Container Apps Environment (load balancer SNAT IP). Container Apps uses this IP when connecting to PostgreSQL public endpoint. Leave empty to skip.')
-param containerAppsStaticIp string = ''
+@description('Public IP of the NAT Gateway attached to the Container Apps subnet. All Container Apps outbound traffic uses this IP when connecting to PostgreSQL public endpoint. Leave empty to skip.')
+param containerAppsNatGatewayIp string = ''
 
 @description('Entra (AAD) object ID of the principal to register as the Active Directory administrator. Leave empty to skip Entra admin setup.')
 param entraAdminObjectId string = ''
@@ -96,7 +96,7 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' =
       startMinute: 0
     }
     network: {
-      publicNetworkAccess: (!empty(adminIpAddresses) || !empty(containerAppsStaticIp)) ? 'Enabled' : 'Disabled'
+      publicNetworkAccess: (!empty(adminIpAddresses) || !empty(containerAppsNatGatewayIp)) ? 'Enabled' : 'Disabled'
     }
   }
 }
@@ -111,16 +111,16 @@ resource adminFirewallRules 'Microsoft.DBforPostgreSQL/flexibleServers/firewallR
   }
 }]
 
-// Firewall rule: allow the Container Apps Environment's static outbound IP.
-// VNet-integrated Container Apps use Azure SNAT (load balancer frontend IP) for outbound
-// connections to public endpoints. The VNet subnet IP range (10.x.x.x) is NOT the source IP
-// — it is SNAT'd to the Container Apps Environment's staticIp before leaving Azure.
-resource containerAppsStaticIpFirewallRule 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = if (!empty(containerAppsStaticIp)) {
+// Firewall rule: allow the NAT Gateway public IP so Container Apps can reach PostgreSQL.
+// VNet-integrated Container Apps route all outbound traffic through the NAT Gateway attached
+// to the Container Apps subnet. Without a NAT Gateway, containers use a large shared pool
+// of ephemeral Azure SNAT IPs (~150+) that cannot be predicted or allowlisted.
+resource containerAppsNatGatewayFirewallRule 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = if (!empty(containerAppsNatGatewayIp)) {
   parent: postgresServer
-  name: 'allow-container-apps-static-ip'
+  name: 'allow-nat-gateway'
   properties: {
-    startIpAddress: containerAppsStaticIp
-    endIpAddress: containerAppsStaticIp
+    startIpAddress: containerAppsNatGatewayIp
+    endIpAddress: containerAppsNatGatewayIp
   }
 }
 
@@ -139,7 +139,7 @@ resource entraAdmin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@20
     principalType: 'ServicePrincipal'
     tenantId: subscription().tenantId
   }
-  dependsOn: [adminFirewallRules, containerAppsStaticIpFirewallRule]
+  dependsOn: [adminFirewallRules, containerAppsNatGatewayFirewallRule]
 }
 
 // Database

--- a/infra/pr-applications.bicep
+++ b/infra/pr-applications.bicep
@@ -79,6 +79,7 @@ module apiApp './modules/api.bicep' = {
     githubRegistryUsername: githubRegistryUsername
     githubRegistryAuthUsername: githubRegistryAuthUsername
     identityId: prManagedIdentity.id
+    identityClientId: prManagedIdentity.properties.clientId
     imageTag: imageTag
     appInsightsConnectionString: '' // disabled — PR telemetry must not reach production dashboards
     keyVaultUri: keyVaultUri

--- a/scripts/Deploy-Infrastructure.ps1
+++ b/scripts/Deploy-Infrastructure.ps1
@@ -269,6 +269,33 @@ if ($Mode -eq 'deploy') {
     }
     Write-Ok "Base infrastructure deployed successfully"
 
+    # Clean up any stale PostgreSQL firewall rules left over from previous infrastructure iterations.
+    # Bicep uses incremental deployments — renaming a rule resource creates the new rule but leaves
+    # the old one as an orphan. The rules below were replaced by 'allow-nat-gateway' in PR #425.
+    Write-Step "Cleaning up stale PostgreSQL firewall rules"
+    $postgresServer = "psql-techhub-prod"
+    $staleRules = @("allow-container-apps-subnet", "allow-container-apps-static-ip")
+    foreach ($ruleName in $staleRules) {
+        try {
+            $rule = Get-AzPostgreSqlFlexibleServerFirewallRule `
+                -ResourceGroupName $resourceGroup `
+                -ServerName $postgresServer `
+                -Name $ruleName `
+                -ErrorAction SilentlyContinue
+            if ($rule) {
+                Remove-AzPostgreSqlFlexibleServerFirewallRule `
+                    -ResourceGroupName $resourceGroup `
+                    -ServerName $postgresServer `
+                    -Name $ruleName
+                Write-Ok "Deleted stale rule: $ruleName"
+            } else {
+                Write-Detail "Rule not present (already clean): $ruleName"
+            }
+        } catch {
+            Write-Warn "Could not check/remove rule '$ruleName': $_"
+        }
+    }
+
     # Sync secrets now that the Key Vault exists.
     # Container Apps reference secrets via keyVaultUrl; they are fetched when the
     # revision starts, so writing them before Phase 2 ensures they are available

--- a/scripts/Deploy-PrPreview.ps1
+++ b/scripts/Deploy-PrPreview.ps1
@@ -79,10 +79,11 @@ $prodIdentityName = 'id-techhub-prod'
 # Production server (source for PITR database clone)
 $prodPostgresServer = 'psql-techhub-prod'
 
-# Container Apps subnet range (no longer used — see containerAppsStaticIp below).
-# Container Apps uses Azure SNAT (load balancer static IP) not the VNet subnet IPs as the
-# outbound source when connecting to PostgreSQL. The static IP is fetched dynamically from
-# the Container Apps environment at deploy time.
+# NAT Gateway public IP resource name — outbound traffic from VNet-integrated Container Apps
+# routes through the NAT Gateway on the Container Apps subnet, NOT through the CAE staticIp
+# (which is the inbound LB frontend). Name follows infra/modules/network.bicep:
+# replace(vnetName, 'vnet-', 'pip-nat-').
+$natGatewayPublicIpName = 'pip-nat-techhub-prod'
 
 # PR-specific resource names
 $prPostgresServer = "psql-techhub-pr-$PrNumber"
@@ -411,27 +412,22 @@ else {
 
 # Add firewall rules for the PR PostgreSQL server.
 # Admin IPs: allow explicit admin access.
-# Container Apps static IP: the prod environment's load balancer SNAT IP — used as the source
-# IP for all outbound connections from Container Apps to PostgreSQL's public endpoint.
+# NAT Gateway IP: all outbound connections from VNet-integrated Container Apps egress through
+# the NAT Gateway attached to the Container Apps subnet — this is the SNAT IP seen by PostgreSQL.
 Write-Step "Configuring PostgreSQL firewall rules for $prPostgresServer"
 
-# Fetch the Container Apps Environment's static outbound IP.
-# This is the SNAT source IP seen by PostgreSQL, not the VNet subnet IP range (10.x.x.x).
-$containerAppsStaticIp = az containerapp env show `
-    --name $prodEnvName `
+# Fetch the NAT Gateway's stable public IP.
+# Do NOT use properties.staticIp from the Container Apps Environment — that is the INBOUND
+# load balancer frontend IP, not the outbound SNAT IP for pods.
+$natGatewayIp = az network public-ip show `
+    --name $natGatewayPublicIpName `
     --resource-group $prodRG `
-    --query properties.staticIp -o tsv 2>&1
-if ($LASTEXITCODE -ne 0) {
-    $containerAppsStaticIpError = ($containerAppsStaticIp | Out-String).Trim()
-    Write-Fail "Could not retrieve Container Apps Environment static IP for env '$prodEnvName' in resource group '$prodRG'. Azure CLI error: $containerAppsStaticIpError"
+    --query properties.ipAddress -o tsv 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($natGatewayIp)) {
+    Write-Fail "Could not retrieve NAT Gateway public IP from '$natGatewayPublicIpName' in '$prodRG'"
     exit 1
 }
-$containerAppsStaticIp = ($containerAppsStaticIp | Out-String).Trim()
-if ([string]::IsNullOrWhiteSpace($containerAppsStaticIp)) {
-    Write-Fail "Could not retrieve Container Apps Environment static IP for env '$prodEnvName' in resource group '$prodRG': the Azure CLI command returned an empty value."
-    exit 1
-}
-Write-Ok "Container Apps static IP: $containerAppsStaticIp"
+Write-Ok "NAT Gateway outbound IP: $natGatewayIp"
 
 # Parse admin IPs from env var
 $adminIps = @($env:ADMIN_IP_ADDRESSES -split ',' | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
@@ -472,66 +468,68 @@ foreach ($ip in $adminIps) {
     $ruleIndex++
 }
 
-# Container Apps static IP rule (idempotent)
-$containerAppsStaticIpRuleName = 'allow-container-apps-static-ip'
+# NAT Gateway firewall rule (idempotent)
+$natGatewayRuleName = 'allow-nat-gateway'
 
-# Clean up any old subnet-range rule from before the SNAT fix (safe to delete, it was ineffective)
-$oldSubnetRuleName = 'allow-container-apps-subnet'
-$oldSubnetRuleJson = az postgres flexible-server firewall-rule list `
-    --resource-group $prodRG `
-    --name $prPostgresServer `
-    --query "[?name=='$oldSubnetRuleName'] | [0]" `
-    --output json 2>$null
-if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($oldSubnetRuleJson) -and $oldSubnetRuleJson -ne 'null') {
-    Write-Detail "Removing old (ineffective) Container Apps subnet firewall rule..."
-    az postgres flexible-server firewall-rule delete `
+# Clean up stale rules from previous Bicep iterations (incremental deployments leave orphans).
+$staleRuleNames = @('allow-container-apps-subnet', 'allow-container-apps-static-ip')
+foreach ($staleRule in $staleRuleNames) {
+    $staleRuleJson = az postgres flexible-server firewall-rule list `
         --resource-group $prodRG `
         --name $prPostgresServer `
-        --rule-name $oldSubnetRuleName `
-        --yes 2>$null | Out-Null
-}
-
-$existingContainerAppsStaticIpRuleJson = az postgres flexible-server firewall-rule list `
-    --resource-group $prodRG `
-    --name $prPostgresServer `
-    --query "[?name=='$containerAppsStaticIpRuleName'] | [0]" `
-    --output json 2>$null
-$existingContainerAppsStaticIpRule = $null
-if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($existingContainerAppsStaticIpRuleJson) -and $existingContainerAppsStaticIpRuleJson -ne 'null') {
-    $existingContainerAppsStaticIpRule = $existingContainerAppsStaticIpRuleJson | ConvertFrom-Json
-}
-
-if ($existingContainerAppsStaticIpRule -and
-    $existingContainerAppsStaticIpRule.startIpAddress -eq $containerAppsStaticIp -and
-    $existingContainerAppsStaticIpRule.endIpAddress -eq $containerAppsStaticIp) {
-    Write-Ok "Container Apps static IP firewall rule already configured"
-}
-else {
-    if ($existingContainerAppsStaticIpRule) {
-        Write-Detail "Replacing stale Container Apps static IP firewall rule..."
+        --query "[?name=='$staleRule'] | [0]" `
+        --output json 2>$null
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($staleRuleJson) -and $staleRuleJson -ne 'null') {
+        Write-Detail "Removing stale firewall rule: $staleRule"
         az postgres flexible-server firewall-rule delete `
             --resource-group $prodRG `
             --name $prPostgresServer `
-            --rule-name $containerAppsStaticIpRuleName `
+            --rule-name $staleRule `
+            --yes 2>$null | Out-Null
+    }
+}
+
+$existingNatRuleJson = az postgres flexible-server firewall-rule list `
+    --resource-group $prodRG `
+    --name $prPostgresServer `
+    --query "[?name=='$natGatewayRuleName'] | [0]" `
+    --output json 2>$null
+$existingNatRule = $null
+if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($existingNatRuleJson) -and $existingNatRuleJson -ne 'null') {
+    $existingNatRule = $existingNatRuleJson | ConvertFrom-Json
+}
+
+if ($existingNatRule -and
+    $existingNatRule.startIpAddress -eq $natGatewayIp -and
+    $existingNatRule.endIpAddress -eq $natGatewayIp) {
+    Write-Ok "NAT Gateway firewall rule already configured"
+}
+else {
+    if ($existingNatRule) {
+        Write-Detail "Replacing stale NAT Gateway firewall rule..."
+        az postgres flexible-server firewall-rule delete `
+            --resource-group $prodRG `
+            --name $prPostgresServer `
+            --rule-name $natGatewayRuleName `
             --yes 2>$null | Out-Null
         if ($LASTEXITCODE -ne 0) {
-            Write-Fail "Failed to remove existing Container Apps static IP firewall rule"
+            Write-Fail "Failed to remove existing NAT Gateway firewall rule"
             exit 1
         }
     }
 
-    Write-Detail "Adding Container Apps static IP firewall rule ($containerAppsStaticIp)..."
+    Write-Detail "Adding NAT Gateway firewall rule ($natGatewayIp)..."
     az postgres flexible-server firewall-rule create `
         --resource-group $prodRG `
         --name $prPostgresServer `
-        --rule-name $containerAppsStaticIpRuleName `
-        --start-ip-address $containerAppsStaticIp `
-        --end-ip-address $containerAppsStaticIp
+        --rule-name $natGatewayRuleName `
+        --start-ip-address $natGatewayIp `
+        --end-ip-address $natGatewayIp
     if ($LASTEXITCODE -ne 0) {
-        Write-Fail "Failed to add Container Apps static IP firewall rule"
+        Write-Fail "Failed to add NAT Gateway firewall rule"
         exit 1
     }
-    Write-Ok "Container Apps static IP firewall rule added"
+    Write-Ok "NAT Gateway firewall rule added"
 }
 
 # ============================================================================


### PR DESCRIPTION
## Problem

The production homepage broke after PR #418 removed the PostgreSQL private endpoint. Two root causes identified and fixed:

### Root cause 1: No stable outbound IP for Container Apps

VNet-integrated Container Apps use a pool of **~150 ephemeral Azure SNAT IPs** for outbound internet traffic. These IPs are shared Azure infrastructure IPs that change unpredictably and cannot be allowlisted in a PostgreSQL firewall.

Previously, the private endpoint (removed by #418) provided a private VNet path to PostgreSQL — no internet routing or SNAT needed. After removing it, Container Apps had to reach PostgreSQL's public IP via SNAT, but there was no way to predict which SNAT IP would be used.

**Fix:** Added a NAT Gateway to the Container Apps subnet. All outbound traffic now exits through a single stable public IP (20.240.202.20), which is allowlisted in the PostgreSQL firewall as \llow-nat-gateway\.

The previous PR #424 attempted to use \containerAppsEnv.properties.staticIp\ as the firewall IP — this was wrong. That property is the **inbound** load balancer frontend IP used by the Envoy ingress proxy, not the outbound SNAT IP used by container pods.

### Root cause 2: AZURE_CLIENT_ID missing for DefaultAzureCredential

After TCP connectivity was restored (via NAT Gateway), the API still crashed because \DefaultAzureCredential.ManagedIdentityCredential\ returned HTTP 400 from the IMDS endpoint.

The IMDS endpoint requires \client_id\ to be specified when using user-assigned managed identities. Without \AZURE_CLIENT_ID\ set in the container's environment, the credential selector couldn't identify which managed identity to use.

**Fix:** Added \identityClientId\ param to \pi.bicep\ and set \AZURE_CLIENT_ID\ env var. \pplications.bicep\ and \pr-applications.bicep\ pass \managedIdentity.properties.clientId\.

## Changes

| File | Change |
|------|--------|
| \infra/modules/network.bicep\ | NAT Gateway + static public IP + subnet association + \
atGatewayPublicIp\ output |
| \infra/modules/containerApps.bicep\ | Remove incorrect \staticIp\ output (was the inbound LB IP, not outbound SNAT IP) |
| \infra/modules/postgres.bicep\ | \containerAppsNatGatewayIp\ param + \llow-nat-gateway\ firewall rule |
| \infra/infrastructure.bicep\ | Wire \
etwork.outputs.natGatewayPublicIp\ to postgres module |
| \infra/modules/api.bicep\ | \identityClientId\ param + \AZURE_CLIENT_ID\ env var |
| \infra/applications.bicep\ | Pass \managedIdentity.properties.clientId\ as \identityClientId\ |
| \infra/pr-applications.bicep\ | Pass \prManagedIdentity.properties.clientId\ as \identityClientId\ |

## Production status

Website is restored. Applied manually before this PR:
- NAT Gateway \
atgw-techhub-prod\ with IP \20.240.202.20\ deployed and associated with \snet-container-apps\
- PostgreSQL firewall rule \llow-nat-gateway\ (20.240.202.20) added; old incorrect rules removed
- \AZURE_CLIENT_ID=061547b7-76bb-4534-9036-9592dc9e036d\ added to \ca-techhub-api-prod\

This PR codifies those manual fixes so future deployments won't regress.