### PR TITLE
Filter client-side noise from failed requests alert

### DIFF
--- a/infra/modules/alerts.bicep
+++ b/infra/modules/alerts.bicep
@@ -54,7 +54,7 @@ resource failedRequestsAlert 'Microsoft.Insights/scheduledQueryRules@2023-03-15-
     criteria: {
       allOf: [
         {
-          query: 'requests\n| where success == false\n| where resultCode != "0"\n| where resultCode != "499"\n| summarize failedCount = count()'
+          query: 'requests\n| where success == false\n| where resultCode != "0"\n| where resultCode != "499"'
           timeAggregation: 'Count'
           operator: 'GreaterThan'
           threshold: 10

--- a/infra/modules/alerts.bicep
+++ b/infra/modules/alerts.bicep
@@ -1,12 +1,12 @@
 // Operational alerts for an environment. Targets:
-// - App Insights: elevated exception rate + failed request rate
+// - App Insights: elevated exception rate + failed request count
 // - Postgres Flexible Server: CPU saturation + connection count
 // - AI Foundry (Cognitive Services account): client errors (429/5xx)
 // - Container Apps: replica restart storms
 //
 // All alerts notify the shared action group.
 
-@description('Azure region (for metric alerts that support regions; log alerts use global)')
+@description('Azure region for all alert resources (metric alerts and log query alerts)')
 param location string = resourceGroup().location
 
 @description('Environment name (staging, prod)')
@@ -33,7 +33,7 @@ param tags object = {}
 var severityHigh = 1
 var severityMedium = 2
 
-// --- Application Insights: failed request rate (log query, noise-filtered) ---
+// --- Application Insights: failed request count (log query, noise-filtered) ---
 // Excludes:
 //   ResultCode=0  — client-aborted Blazor SignalR circuits and bot connections that
 //                   drop the WebSocket before the server can respond. Always client-side.

--- a/infra/modules/alerts.bicep
+++ b/infra/modules/alerts.bicep
@@ -33,37 +33,41 @@ param tags object = {}
 var severityHigh = 1
 var severityMedium = 2
 
-// --- Application Insights: failed request rate ---
-resource failedRequestsAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+// --- Application Insights: failed request rate (log query, noise-filtered) ---
+// Excludes:
+//   ResultCode=0  — client-aborted Blazor SignalR circuits and bot connections that
+//                   drop the WebSocket before the server can respond. Always client-side.
+//   HTTP 499      — client closed the connection before the server finished responding.
+//                   Unactionable; spikes during outages are captured by availability tests.
+resource failedRequestsAlert 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
   name: 'alert-${environmentName}-failed-requests'
-  location: 'global'
+  location: location
   tags: tags
   properties: {
-    description: 'Fires when failed HTTP requests exceed 10 in 15 minutes.'
+    displayName: 'Failed HTTP requests (${environmentName})'
+    description: 'Fires when actionable failed requests exceed 10 in 15 minutes. Excludes ResultCode=0 (client-aborted) and HTTP 499 (client disconnect).'
     severity: severityHigh
     enabled: true
-    scopes: [appInsightsId]
     evaluationFrequency: 'PT5M'
     windowSize: 'PT15M'
+    scopes: [logAnalyticsWorkspaceId]
     criteria: {
-      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
       allOf: [
         {
-          name: 'FailedRequests'
-          metricNamespace: 'microsoft.insights/components'
-          metricName: 'requests/failed'
+          query: 'requests\n| where success == false\n| where resultCode != "0"\n| where resultCode != "499"\n| summarize failedCount = count()'
+          timeAggregation: 'Count'
           operator: 'GreaterThan'
           threshold: 10
-          timeAggregation: 'Count'
-          criterionType: 'StaticThresholdCriterion'
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
         }
       ]
     }
-    actions: [
-      {
-        actionGroupId: actionGroupId
-      }
-    ]
+    actions: {
+      actionGroups: [actionGroupId]
+    }
   }
 }
 


### PR DESCRIPTION
- [x] Fix KQL summarize issue (already done)
- [x] Rename "failed request rate" to "failed request count" in comments (lines 2 and 36)
- [x] Update `location` parameter description to remove incorrect "log alerts use global" note