### PR TITLE
feat: newsletter topic selection modal

### DIFF
--- a/src/TechHub.Web/Components/NewsletterModal.razor
+++ b/src/TechHub.Web/Components/NewsletterModal.razor
@@ -1,0 +1,214 @@
+@using Microsoft.Extensions.Options
+@using TechHub.Web.Configuration
+@inject IOptions<NewsletterSettings> NewsletterOptions
+
+@*
+    NewsletterModal — Topic-selection newsletter subscription modal.
+
+    Shows checkboxes for each configured Mailchimp interest group (topic).
+    When NewsletterSettings.Enabled is false, displays a "coming soon" notice instead.
+
+    Form submits directly to Mailchimp's list-manage endpoint in a new tab (target="_blank")
+    to avoid CORS restrictions on the free plan.
+
+    Usage (open from a sidebar button):
+      <NewsletterModal @ref="_newsletterModal" />
+      ...
+      <button @onclick="() => _newsletterModal?.Open()">Newsletter</button>
+
+    With a pre-selected topic (section pages):
+      <NewsletterModal @ref="_newsletterModal" PreSelectedTopic="github-copilot" />
+*@
+
+@if (_isOpen)
+{
+    <div class="newsletter-backdrop"
+         @onclick="Close"
+         role="dialog"
+         aria-modal="true"
+         aria-labelledby="newsletter-modal-title">
+        <div class="newsletter-modal" @onclick:stopPropagation>
+            <div class="newsletter-modal-header">
+                <h2 id="newsletter-modal-title" class="newsletter-modal-title">Subscribe to Newsletter</h2>
+                <button type="button" class="newsletter-modal-close" @onclick="Close" aria-label="Close">×</button>
+            </div>
+
+            <div class="newsletter-modal-body">
+                @if (!_settings.Enabled)
+                {
+                    <div class="newsletter-coming-soon">
+                        <svg class="newsletter-coming-soon-icon" width="32" height="32" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z" />
+                        </svg>
+                        <p class="newsletter-coming-soon-title">Newsletter coming soon!</p>
+                        <p class="newsletter-coming-soon-text">
+                            We&apos;re setting up topic-based newsletters so you can subscribe to exactly what interests you.
+                            Check back soon, or follow our RSS feeds in the meantime.
+                        </p>
+                    </div>
+                }
+                else
+                {
+                    <p class="newsletter-intro">
+                        Choose the topics you want to receive updates about. You&apos;ll get a single weekly digest covering only your selected topics.
+                    </p>
+
+                    <form method="post"
+                          action="@_settings.FormActionUrl"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          @onsubmit="HandleSubmit">
+
+                        @* Mailchimp required hidden fields *@
+                        <input type="hidden" name="u" value="@_settings.UserId" />
+                        <input type="hidden" name="id" value="@_settings.ListId" />
+
+                        @* Mailchimp anti-bot honeypot field — must be empty *@
+                        <div style="position: absolute; left: -5000px;" aria-hidden="true">
+                            <input type="text" name="@($"b_{_settings.UserId}_{_settings.ListId}")" tabindex="-1" value="" autocomplete="off" />
+                        </div>
+
+                        <div class="newsletter-form-group">
+                            <label for="newsletter-email" class="newsletter-label">Email address</label>
+                            <input id="newsletter-email"
+                                   type="email"
+                                   name="EMAIL"
+                                   class="newsletter-email-input"
+                                   placeholder="you@example.com"
+                                   required
+                                   @bind="_email"
+                                   @bind:event="oninput" />
+                        </div>
+
+                        <fieldset class="newsletter-topics-fieldset">
+                            <legend class="newsletter-label">Topics</legend>
+
+                            @* Subscribe to all convenience option *@
+                            <label class="newsletter-topic-label newsletter-topic-all">
+                                <input type="checkbox"
+                                       @bind="_subscribeToAll"
+                                       @bind:after="HandleSubscribeToAllChanged" />
+                                <strong>All topics</strong>
+                                <span class="newsletter-topic-desc">Receive updates for every topic</span>
+                            </label>
+
+                            <div class="newsletter-topics-divider"></div>
+
+                            @foreach (var (slug, topic) in _settings.Topics)
+                            {
+                                var isChecked = _selectedTopics.Contains(slug);
+                                <label class="newsletter-topic-label">
+                                    @* Mailchimp group checkbox: name format is group[GroupId][GroupValue] *@
+                                    <input type="checkbox"
+                                           name="@($"group[{topic.GroupId}][{topic.GroupValue}]")"
+                                           value="@topic.GroupValue"
+                                           checked="@isChecked"
+                                           @onchange="@(e => HandleTopicChanged(slug, (bool)(e.Value ?? false)))" />
+                                    <span>@topic.Label</span>
+                                </label>
+                            }
+                        </fieldset>
+
+                        <div class="newsletter-modal-footer">
+                            <button type="submit"
+                                    class="btn"
+                                    disabled="@(!CanSubmit)">
+                                Subscribe
+                            </button>
+                            <button type="button" class="btn-secondary" @onclick="Close">Cancel</button>
+                        </div>
+                    </form>
+                }
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    /// <summary>
+    /// Optional section slug to pre-select when the modal opens (e.g. "github-copilot").
+    /// Ignored if the slug is not in the configured topics.
+    /// </summary>
+    [Parameter]
+    public string? PreSelectedTopic { get; set; }
+
+    private NewsletterSettings _settings = new();
+    private bool _isOpen;
+    private string _email = string.Empty;
+    private bool _subscribeToAll;
+    private readonly HashSet<string> _selectedTopics = new(StringComparer.OrdinalIgnoreCase);
+
+    private bool CanSubmit =>
+        !string.IsNullOrWhiteSpace(_email)
+        && _email.Contains('@')
+        && _selectedTopics.Count > 0;
+
+    protected override void OnInitialized()
+    {
+        _settings = NewsletterOptions.Value;
+    }
+
+    /// <summary>
+    /// Opens the modal. Call this from a parent component's button @onclick handler.
+    /// </summary>
+    public void Open()
+    {
+        _email = string.Empty;
+        _subscribeToAll = false;
+        _selectedTopics.Clear();
+
+        // Pre-select the section topic if provided and configured
+        if (!string.IsNullOrEmpty(PreSelectedTopic)
+            && _settings.Topics.ContainsKey(PreSelectedTopic))
+        {
+            _selectedTopics.Add(PreSelectedTopic);
+        }
+
+        _isOpen = true;
+        StateHasChanged();
+    }
+
+    private void Close()
+    {
+        _isOpen = false;
+    }
+
+    private void HandleSubscribeToAllChanged()
+    {
+        if (_subscribeToAll)
+        {
+            foreach (var slug in _settings.Topics.Keys)
+            {
+                _selectedTopics.Add(slug);
+            }
+        }
+        else
+        {
+            _selectedTopics.Clear();
+        }
+    }
+
+    private void HandleTopicChanged(string slug, bool isChecked)
+    {
+        if (isChecked)
+        {
+            _selectedTopics.Add(slug);
+        }
+        else
+        {
+            _selectedTopics.Remove(slug);
+            // Uncheck "all" if any individual topic is deselected
+            _subscribeToAll = false;
+        }
+
+        // Auto-check "all" when every topic is individually selected
+        _subscribeToAll = _selectedTopics.Count == _settings.Topics.Count;
+    }
+
+    private void HandleSubmit()
+    {
+        // The form submits natively via target="_blank" to Mailchimp.
+        // Close the modal after the browser opens the new tab.
+        _isOpen = false;
+    }
+}

--- a/src/TechHub.Web/Components/NewsletterModal.razor.css
+++ b/src/TechHub.Web/Components/NewsletterModal.razor.css
@@ -1,0 +1,201 @@
+/* NewsletterModal.razor.css — scoped styles for newsletter subscription modal */
+
+.newsletter-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--color-black-backdrop);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: var(--spacing-2);
+}
+
+.newsletter-modal {
+    background: var(--color-bg-elevated);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    width: min(480px, 100%);
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.newsletter-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--spacing-2) var(--spacing-3);
+    border-bottom: 1px solid var(--color-border-default);
+    gap: var(--spacing-2);
+}
+
+.newsletter-modal-title {
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+    margin: 0;
+}
+
+.newsletter-modal-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-xl);
+    line-height: 1;
+    padding: 0 var(--spacing-1);
+    border-radius: var(--radius-sm);
+    transition: color var(--transition-fast);
+
+    &:hover {
+        color: var(--color-text-primary);
+    }
+}
+
+.newsletter-modal-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--spacing-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-3);
+}
+
+/* Coming-soon notice */
+
+.newsletter-coming-soon {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-2);
+    text-align: center;
+    padding: var(--spacing-3) 0;
+}
+
+.newsletter-coming-soon-icon {
+    color: var(--color-purple-medium);
+    opacity: 0.8;
+}
+
+.newsletter-coming-soon-title {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-emphasis);
+    margin: 0;
+}
+
+.newsletter-coming-soon-text {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    margin: 0;
+    max-width: 320px;
+}
+
+/* Form */
+
+.newsletter-intro {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    margin: 0;
+}
+
+.newsletter-form-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+}
+
+.newsletter-label {
+    display: block;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+}
+
+.newsletter-email-input {
+    width: 100%;
+    padding: var(--spacing-1) var(--spacing-2);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    background: var(--color-bg-default);
+    color: var(--color-text-primary);
+    font-size: var(--font-size-sm);
+    font-family: var(--font-family-base);
+    box-sizing: border-box;
+    transition: border-color var(--transition-fast);
+
+    &:focus {
+        outline: none;
+        border-color: var(--color-purple-medium);
+        box-shadow: 0 0 0 2px var(--color-purple-bg-subtle);
+    }
+}
+
+/* Topics fieldset */
+
+.newsletter-topics-fieldset {
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    padding: var(--spacing-2);
+    background: var(--color-bg-emphasis);
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+}
+
+.newsletter-topics-fieldset legend {
+    padding: 0 var(--spacing-1);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+}
+
+.newsletter-topic-label {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-primary);
+    padding: var(--spacing-1) var(--spacing-1);
+    border-radius: var(--radius-sm);
+    transition: background-color var(--transition-fast);
+
+    &:hover {
+        background: var(--color-bg-hover-subtle);
+    }
+
+    input[type="checkbox"] {
+        accent-color: var(--color-purple-medium);
+        width: 16px;
+        height: 16px;
+        cursor: pointer;
+        flex-shrink: 0;
+    }
+}
+
+.newsletter-topic-all {
+    font-weight: var(--font-weight-medium);
+}
+
+.newsletter-topic-desc {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+}
+
+.newsletter-topics-divider {
+    height: 1px;
+    background: var(--color-border-default);
+    margin: var(--spacing-1) 0;
+}
+
+/* Footer */
+
+.newsletter-modal-footer {
+    display: flex;
+    gap: var(--spacing-1);
+    padding-top: var(--spacing-2);
+}

--- a/src/TechHub.Web/Components/Pages/Home.razor
+++ b/src/TechHub.Web/Components/Pages/Home.razor
@@ -12,6 +12,8 @@
     ContentType="SeoMetaTags.SeoContentType.Website"
     RssFeedUrl="/all/feed.xml" />
 
+<NewsletterModal @ref="_newsletterModal" />
+
 <main class="page-with-sidebar">
     @* Sidebar (Left Column) *@
     <aside class="sidebar">
@@ -83,7 +85,7 @@
         </MobileSidebarPanel>
         </MobileSidebarToolbar>
         <div class="sidebar-desktop-only">
-        <SidebarRssLinks Links="@rssLinks" />
+        <SidebarRssLinks Links="@rssLinks" OnNewsletterClick="@OpenNewsletterModal" />
         </div>
     </aside>
 
@@ -109,22 +111,19 @@
     [Inject] public required PersistentComponentState ApplicationState { get; set; }
 
     private PersistingComponentStateSubscription? _persistSubscription;
+    private NewsletterModal? _newsletterModal;
 
     private static readonly SidebarRssLinks.RssLink[] rssLinks =
     [
         new("RSS Feed - All Content", "/all/feed.xml"),
-        new("Newsletter", "https://mailchi.mp/1c8d4b5ea99c/tech-hub", GetNewsletterIcon())
+        new("Newsletter", null)
     ];
 
     private IEnumerable<TechHub.Core.Models.Section>? sections;
     private IEnumerable<TechHub.Core.Models.ContentItem>? latestRoundups;
     private IEnumerable<TechHub.Core.Models.ContentItem>? latestItems;
 
-    private static RenderFragment GetNewsletterIcon() => @<svg width="16" height="16" viewBox="0 0 24 24"
-            fill="currentColor" aria-hidden="true">
-            <path
-                d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z" />
-    </svg>;
+    private void OpenNewsletterModal() => _newsletterModal?.Open();
 
     private string GetItemSectionTitle(string sectionName)
     {

--- a/src/TechHub.Web/Components/Pages/SectionCollection.razor
+++ b/src/TechHub.Web/Components/Pages/SectionCollection.razor
@@ -17,6 +17,8 @@
     Breadcrumbs="@GetBreadcrumbs()"
     RssFeedUrl="@($"/{SectionName}/feed.xml")" />
 
+<NewsletterModal @ref="_newsletterModal" PreSelectedTopic="@SectionName" />
+
 <main class="page-with-sidebar">
     <aside class="sidebar">
         <SidebarToggle />
@@ -56,7 +58,9 @@
         </MobileSidebarPanel>
         </MobileSidebarToolbar>
         <div class="sidebar-desktop-only">
-        <SidebarRssLinks Links="@(new[] { new SidebarRssLinks.RssLink("RSS Feed", $"/{SectionName}/feed.xml") })" />
+        <SidebarRssLinks
+            Links="@(new[] { new SidebarRssLinks.RssLink("RSS Feed", $"/{SectionName}/feed.xml"), new SidebarRssLinks.RssLink("Newsletter", null) })"
+            OnNewsletterClick="@OpenNewsletterModal" />
         </div>
     </aside>
 
@@ -76,6 +80,9 @@
 @code {
     [Parameter]
     public string SectionName { get; set; } = null!;
+
+    private NewsletterModal? _newsletterModal;
+    private void OpenNewsletterModal() => _newsletterModal?.Open();
 
     [Parameter]
     public string? CollectionName { get; set; }

--- a/src/TechHub.Web/Components/SidebarRssLinks.razor
+++ b/src/TechHub.Web/Components/SidebarRssLinks.razor
@@ -2,17 +2,16 @@
    Sidebar RSS Links Component
    
    Renders RSS feed subscription links with icons.
-   Supports single or multiple RSS feeds.
+   Supports single or multiple RSS feeds, and an optional newsletter button.
    
    Usage:
-     Single feed (section pages):
+     Section pages (RSS only):
        <SidebarRssLinks Links="@(new[] { new RssLink("RSS Feed", "/ai/feed.xml") })" />
      
-      Homepage feed links:
-        <SidebarRssLinks Links="@(new[] {
-            new RssLink("RSS Feed - All Content", "/all/feed.xml")
-        })" />
-   ============================================================================ *@
+     Homepage with newsletter modal button:
+       <SidebarRssLinks Links="@links" OnNewsletterClick="@OpenModal" />
+       where links contains: new RssLink("Newsletter", null)
+============================================================================ *@
 
 <div class="sidebar-section">
     <h2 class="sidebar-h2">Subscribe</h2>
@@ -20,20 +19,20 @@
         @foreach (var link in Links)
         {
             <li>
-                <a href="@link.Url" target="_blank" rel="noopener noreferrer" class="sidebar-link-button">
-                    @if (link.Icon != null)
-                    {
-                        @link.Icon
-                    }
-                    else
-                    {
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                            <path
-                                d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19 7.38 20 6.18 20C5 20 4 19 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z" />
-                        </svg>
-                    }
-                    @link.Title
-                </a>
+                @if (link.Url is null && OnNewsletterClick.HasDelegate)
+                {
+                    <button type="button" class="sidebar-link-button" @onclick="OnNewsletterClick">
+                        @GetIcon(link)
+                        @link.Title
+                    </button>
+                }
+                else if (link.Url is not null)
+                {
+                    <a href="@link.Url" target="_blank" rel="noopener noreferrer" class="sidebar-link-button">
+                        @GetIcon(link)
+                        @link.Title
+                    </a>
+                }
             </li>
         }
     </ul>
@@ -43,5 +42,30 @@
     [Parameter, EditorRequired]
     public required IEnumerable<RssLink> Links { get; set; }
 
-    public record RssLink(string Title, string Url, RenderFragment? Icon = null);
+    /// <summary>
+    /// Callback invoked when a newsletter link (Url = null) is clicked.
+    /// Used to open the NewsletterModal from the parent page.
+    /// </summary>
+    [Parameter]
+    public EventCallback OnNewsletterClick { get; set; }
+
+    public record RssLink(string Title, string? Url, RenderFragment? Icon = null);
+
+    private static RenderFragment DefaultRssIcon => @<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19 7.38 20 6.18 20C5 20 4 19 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z" />
+    </svg>;
+
+    private static RenderFragment NewsletterIcon => @<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z" />
+    </svg>;
+
+    private static RenderFragment GetIcon(RssLink link)
+    {
+        if (link.Icon is not null)
+        {
+            return link.Icon;
+        }
+
+        return link.Url is null ? NewsletterIcon : DefaultRssIcon;
+    }
 }

--- a/src/TechHub.Web/Configuration/NewsletterSettings.cs
+++ b/src/TechHub.Web/Configuration/NewsletterSettings.cs
@@ -1,0 +1,59 @@
+namespace TechHub.Web.Configuration;
+
+/// <summary>
+/// Configuration for the newsletter subscription modal.
+/// Maps to the "Newsletter" section in appsettings.json.
+/// </summary>
+public sealed class NewsletterSettings
+{
+    public const string SectionName = "Newsletter";
+
+    /// <summary>
+    /// When false (default), the modal displays a "coming soon" message instead of the subscription form.
+    /// Set to true once the Mailchimp account and interest groups are configured.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Mailchimp form POST URL.
+    /// Example: https://yourdomain.us1.list-manage.com/subscribe/post
+    /// </summary>
+    public string FormActionUrl { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Mailchimp audience user ID (the 'u' parameter in the embedded form).
+    /// </summary>
+    public string UserId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Mailchimp audience list ID (the 'id' parameter in the embedded form).
+    /// </summary>
+    public string ListId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Per-topic interest group configuration.
+    /// Key is the section slug (e.g. "ai", "github-copilot").
+    /// </summary>
+    public Dictionary<string, NewsletterTopic> Topics { get; init; } = [];
+}
+
+/// <summary>
+/// Configuration for a single newsletter topic / Mailchimp interest group.
+/// </summary>
+public sealed class NewsletterTopic
+{
+    /// <summary>
+    /// Human-readable label shown in the modal checkbox (e.g. "AI", "GitHub Copilot").
+    /// </summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Mailchimp interest group ID. Used as the checkbox input name: group[GroupId][GroupValue].
+    /// </summary>
+    public string GroupId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Mailchimp interest group value. Used as the checkbox input value.
+    /// </summary>
+    public string GroupValue { get; init; } = string.Empty;
+}

--- a/src/TechHub.Web/Program.cs
+++ b/src/TechHub.Web/Program.cs
@@ -15,6 +15,7 @@ using TechHub.Core.Models;
 using TechHub.Core.Validation;
 using TechHub.ServiceDefaults;
 using TechHub.Web.Components;
+using TechHub.Web.Configuration;
 using TechHub.Web.Middleware;
 using TechHub.Web.Services;
 using TechHub.Web.Telemetry;
@@ -163,6 +164,10 @@ builder.Services.AddScoped<ContentGridStateCache>();
 
 // Domain-based branding (tech.xebia.ms vs tech.hub.ms)
 builder.Services.AddScoped<BrandingService>();
+
+// Newsletter subscription settings (Mailchimp interest groups per topic)
+builder.Services.Configure<NewsletterSettings>(
+    builder.Configuration.GetSection(NewsletterSettings.SectionName));
 
 // Configure SignalR for Blazor Server with increased timeouts for reliability
 builder.Services.AddSignalR(options =>

--- a/src/TechHub.Web/appsettings.json
+++ b/src/TechHub.Web/appsettings.json
@@ -49,6 +49,21 @@
       }
     }
   },
+  "Newsletter": {
+    "Enabled": false,
+    "FormActionUrl": "https://REPLACE.us1.list-manage.com/subscribe/post",
+    "UserId": "REPLACE_WITH_MAILCHIMP_USER_ID",
+    "ListId": "REPLACE_WITH_MAILCHIMP_LIST_ID",
+    "Topics": {
+      "ai":             { "Label": "AI",              "GroupId": "REPLACE", "GroupValue": "1"  },
+      "github-copilot": { "Label": "GitHub Copilot",  "GroupId": "REPLACE", "GroupValue": "2"  },
+      "ml":             { "Label": "Machine Learning", "GroupId": "REPLACE", "GroupValue": "4"  },
+      "azure":          { "Label": "Azure",            "GroupId": "REPLACE", "GroupValue": "8"  },
+      "dotnet":         { "Label": ".NET",             "GroupId": "REPLACE", "GroupValue": "16" },
+      "devops":         { "Label": "DevOps",           "GroupId": "REPLACE", "GroupValue": "32" },
+      "security":       { "Label": "Security",         "GroupId": "REPLACE", "GroupValue": "64" }
+    }
+  },
   "AllowedHosts": "*",
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",

--- a/tests/TechHub.Web.Tests/Components/NewsletterModalTests.cs
+++ b/tests/TechHub.Web.Tests/Components/NewsletterModalTests.cs
@@ -1,0 +1,314 @@
+using AngleSharp.Html.Dom;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using TechHub.Web.Components;
+using TechHub.Web.Configuration;
+
+namespace TechHub.Web.Tests.Components;
+
+/// <summary>
+/// Tests for NewsletterModal.razor component.
+///
+/// Covers:
+/// - "Coming soon" notice when newsletter is disabled
+/// - Topic checkboxes rendered when newsletter is enabled
+/// - "Subscribe to all" toggles all topic checkboxes
+/// - Deselecting a topic unchecks "subscribe to all"
+/// - Submit button disabled when email or topics are missing
+/// - Submit button enabled when email and at least one topic are provided
+/// - Pre-selected topic is checked when the modal opens
+/// - Closing via × or backdrop clears the modal
+/// </summary>
+public class NewsletterModalTests : BunitContext
+{
+    private static readonly NewsletterSettings DisabledSettings = new()
+    {
+        Enabled = false
+    };
+
+    private static readonly NewsletterSettings EnabledSettings = new()
+    {
+        Enabled = true,
+        FormActionUrl = "https://example.us1.list-manage.com/subscribe/post",
+        UserId = "test_user",
+        ListId = "test_list",
+        Topics = new Dictionary<string, NewsletterTopic>
+        {
+            ["ai"]      = new() { Label = "AI",     GroupId = "100", GroupValue = "1" },
+            ["azure"]   = new() { Label = "Azure",  GroupId = "100", GroupValue = "2" },
+            ["dotnet"]  = new() { Label = ".NET",   GroupId = "100", GroupValue = "4" }
+        }
+    };
+
+    private void RegisterSettings(NewsletterSettings settings) =>
+        Services.AddSingleton<IOptions<NewsletterSettings>>(Options.Create(settings));
+
+    // ─── Coming-soon notice ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NewsletterModal_WhenDisabled_ShowsComingSoonNotice()
+    {
+        RegisterSettings(DisabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll(".newsletter-coming-soon").Count > 0);
+
+        cut.Find(".newsletter-coming-soon").Should().NotBeNull();
+        cut.Find(".newsletter-coming-soon-title").TextContent.ToLowerInvariant().Should()
+            .Contain("coming soon");
+    }
+
+    [Fact]
+    public async Task NewsletterModal_WhenDisabled_DoesNotRenderForm()
+    {
+        RegisterSettings(DisabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll(".newsletter-coming-soon").Count > 0);
+
+        cut.FindAll("form").Should().BeEmpty("form must not be rendered when newsletter is disabled");
+    }
+
+    // ─── Topic checkboxes ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NewsletterModal_WhenEnabled_RendersTopicCheckboxes()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        // 3 topic checkboxes + 1 "subscribe to all" = 4 total
+        var checkboxes = cut.FindAll("input[type='checkbox']");
+        checkboxes.Count.Should().Be(EnabledSettings.Topics.Count + 1,
+            "one checkbox per topic plus one for subscribe-to-all");
+    }
+
+    [Fact]
+    public async Task NewsletterModal_WhenEnabled_RendersTopicLabels()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        var markup = cut.Markup;
+        markup.Should().Contain("AI");
+        markup.Should().Contain("Azure");
+        markup.Should().Contain(".NET");
+    }
+
+    // ─── Subscribe to all ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NewsletterModal_SubscribeToAll_ChecksAllTopicCheckboxes()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        // The first checkbox is "subscribe to all"; click it
+        var subscribeToAll = cut.Find(".newsletter-topic-all input[type='checkbox']");
+        subscribeToAll.Change(true);
+
+        // All individual topic checkboxes should now be checked
+        var topicCheckboxes = cut.FindAll(".newsletter-topics-fieldset input[type='checkbox']")
+            .Skip(1) // skip subscribe-to-all
+            .ToList();
+
+        topicCheckboxes.Should().AllSatisfy(cb =>
+            ((IHtmlInputElement)cb).IsChecked.Should().BeTrue("all topics should be checked after subscribe-to-all"));
+    }
+
+    [Fact]
+    public async Task NewsletterModal_UnchecksSubscribeToAll_WhenTopicDeselected()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        // Check "subscribe to all"
+        var subscribeToAll = cut.Find(".newsletter-topic-all input[type='checkbox']");
+        subscribeToAll.Change(true);
+
+        // Now uncheck one topic
+        var firstTopicCheckbox = cut.FindAll(".newsletter-topics-fieldset input[type='checkbox']")
+            .Skip(1)
+            .First();
+        firstTopicCheckbox.Change(false);
+
+        // "Subscribe to all" should be unchecked
+        ((IHtmlInputElement)subscribeToAll).IsChecked.Should().BeFalse(
+            "subscribe-to-all must uncheck when any individual topic is deselected");
+    }
+
+    // ─── Submit button state ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NewsletterModal_SubmitButton_DisabledWhenNoEmail()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        // Select a topic but leave email empty
+        var firstTopic = cut.FindAll(".newsletter-topics-fieldset input[type='checkbox']")
+            .Skip(1)
+            .First();
+        firstTopic.Change(true);
+
+        var submitButton = cut.Find("button[type='submit']");
+        submitButton.HasAttribute("disabled").Should().BeTrue("submit must be disabled without a valid email");
+    }
+
+    [Fact]
+    public async Task NewsletterModal_SubmitButton_DisabledWhenNoTopicSelected()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        // Provide an email but select no topic
+        var emailInput = cut.Find("input[type='email']");
+        emailInput.Input("user@example.com");
+
+        var submitButton = cut.Find("button[type='submit']");
+        submitButton.HasAttribute("disabled").Should().BeTrue("submit must be disabled without any topic selected");
+    }
+
+    [Fact]
+    public async Task NewsletterModal_SubmitButton_EnabledWhenEmailAndTopicProvided()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        // Provide email
+        var emailInput = cut.Find("input[type='email']");
+        emailInput.Input("user@example.com");
+
+        // Select a topic
+        var firstTopic = cut.FindAll(".newsletter-topics-fieldset input[type='checkbox']")
+            .Skip(1)
+            .First();
+        firstTopic.Change(true);
+
+        var submitButton = cut.Find("button[type='submit']");
+        submitButton.HasAttribute("disabled").Should().BeFalse("submit must be enabled when email and at least one topic are provided");
+    }
+
+    // ─── Pre-selected topic ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NewsletterModal_WithPreSelectedTopic_ChecksMatchingCheckbox()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>(p => p.Add(m => m.PreSelectedTopic, "azure"));
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        // The Azure checkbox should be checked; AI and .NET should not
+        var checkboxes = cut.FindAll(".newsletter-topics-fieldset input[type='checkbox']")
+            .Skip(1) // skip subscribe-to-all
+            .ToList();
+
+        // Exactly one checkbox should be checked (Azure)
+        var checkedCount = checkboxes.Count(cb => ((IHtmlInputElement)cb).IsChecked);
+        checkedCount.Should().Be(1, "only the pre-selected topic should be checked");
+    }
+
+    [Fact]
+    public async Task NewsletterModal_WithUnknownPreSelectedTopic_ChecksNothing()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>(p => p.Add(m => m.PreSelectedTopic, "nonexistent"));
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        var topicCheckboxes = cut.FindAll(".newsletter-topics-fieldset input[type='checkbox']")
+            .Skip(1)
+            .ToList();
+
+        topicCheckboxes.Should().AllSatisfy(cb =>
+            ((IHtmlInputElement)cb).IsChecked.Should().BeFalse("unknown topic should not check any checkbox"));
+    }
+
+    // ─── Close behaviour ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NewsletterModal_CloseButton_HidesModal()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll(".newsletter-modal").Count > 0);
+
+        cut.Find(".newsletter-modal-close").Click();
+
+        cut.FindAll(".newsletter-modal").Should().BeEmpty("modal must be hidden after close button click");
+    }
+
+    [Fact]
+    public async Task NewsletterModal_Backdrop_Click_HidesModal()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll(".newsletter-backdrop").Count > 0);
+
+        cut.Find(".newsletter-backdrop").Click();
+
+        cut.FindAll(".newsletter-backdrop").Should().BeEmpty("modal must be hidden after backdrop click");
+    }
+
+    // ─── Mailchimp field names ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NewsletterModal_Form_ContainsHiddenMailchimpFields()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        cut.Find("input[name='u']").Should().NotBeNull("Mailchimp user ID hidden field must be present");
+        cut.Find("input[name='id']").Should().NotBeNull("Mailchimp list ID hidden field must be present");
+    }
+
+    [Fact]
+    public async Task NewsletterModal_Form_PostsToConfiguredActionUrl()
+    {
+        RegisterSettings(EnabledSettings);
+        var cut = Render<NewsletterModal>();
+
+        await cut.InvokeAsync(() => cut.Instance.Open());
+        cut.WaitForState(() => cut.FindAll("form").Count > 0);
+
+        var form = cut.Find("form");
+        form.GetAttribute("action").Should().Be(EnabledSettings.FormActionUrl);
+        form.GetAttribute("method").ToLowerInvariant().Should().Be("post");
+        form.GetAttribute("target").Should().Be("_blank");
+    }
+}

--- a/tests/TechHub.Web.Tests/Components/SidebarRssLinksTests.cs
+++ b/tests/TechHub.Web.Tests/Components/SidebarRssLinksTests.cs
@@ -1,0 +1,98 @@
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using TechHub.Web.Components;
+
+namespace TechHub.Web.Tests.Components;
+
+/// <summary>
+/// Tests for SidebarRssLinks.razor component.
+///
+/// Covers:
+/// - RSS links render as anchor tags with correct href
+/// - Newsletter entry (Url = null) renders as a button instead of an anchor
+/// - Newsletter button invokes OnNewsletterClick callback
+/// - Links with explicit Url render as external anchors
+/// </summary>
+public class SidebarRssLinksTests : BunitContext
+{
+    [Fact]
+    public void SidebarRssLinks_RssLink_RendersAsAnchor()
+    {
+        var links = new[] { new SidebarRssLinks.RssLink("RSS Feed", "/ai/feed.xml") };
+
+        var cut = Render<SidebarRssLinks>(p => p.Add(c => c.Links, links));
+
+        var anchor = cut.Find("a");
+        anchor.Should().NotBeNull();
+        anchor.GetAttribute("href").Should().Be("/ai/feed.xml");
+        anchor.TextContent.Should().Contain("RSS Feed");
+    }
+
+    [Fact]
+    public void SidebarRssLinks_NewsletterLink_RendersAsButton()
+    {
+        var links = new[] { new SidebarRssLinks.RssLink("Newsletter", null) };
+
+        var cut = Render<SidebarRssLinks>(p =>
+        {
+            p.Add(c => c.Links, links);
+            p.Add(c => c.OnNewsletterClick, EventCallback.Factory.Create(this, () => { }));
+        });
+
+        // Should render a button, not an anchor
+        cut.FindAll("button").Should().HaveCount(1, "newsletter entry without Url must render as a button");
+        cut.FindAll("a").Should().BeEmpty("newsletter entry must not render as an anchor");
+
+        cut.Find("button").TextContent.Should().Contain("Newsletter");
+    }
+
+    [Fact]
+    public void SidebarRssLinks_NewsletterButton_InvokesCallback()
+    {
+        var clicked = false;
+        var links = new[] { new SidebarRssLinks.RssLink("Newsletter", null) };
+
+        var cut = Render<SidebarRssLinks>(p =>
+        {
+            p.Add(c => c.Links, links);
+            p.Add(c => c.OnNewsletterClick, EventCallback.Factory.Create(this, () => clicked = true));
+        });
+
+        cut.Find("button").Click();
+
+        clicked.Should().BeTrue("clicking the newsletter button must invoke OnNewsletterClick");
+    }
+
+    [Fact]
+    public void SidebarRssLinks_MultipleLinks_RendersAll()
+    {
+        var links = new[]
+        {
+            new SidebarRssLinks.RssLink("RSS Feed", "/all/feed.xml"),
+            new SidebarRssLinks.RssLink("Newsletter", null)
+        };
+
+        var cut = Render<SidebarRssLinks>(p =>
+        {
+            p.Add(c => c.Links, links);
+            p.Add(c => c.OnNewsletterClick, EventCallback.Factory.Create(this, () => { }));
+        });
+
+        cut.FindAll("li").Should().HaveCount(2, "one list item per link");
+        cut.FindAll("a").Should().HaveCount(1, "only the RSS link should be an anchor");
+        cut.FindAll("button").Should().HaveCount(1, "only the newsletter link should be a button");
+    }
+
+    [Fact]
+    public void SidebarRssLinks_RssLink_HasExternalAttributes()
+    {
+        var links = new[] { new SidebarRssLinks.RssLink("RSS Feed", "/ai/feed.xml") };
+
+        var cut = Render<SidebarRssLinks>(p => p.Add(c => c.Links, links));
+
+        var anchor = cut.Find("a");
+        anchor.GetAttribute("target").Should().Be("_blank");
+        anchor.GetAttribute("rel").Should().Contain("noopener");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a newsletter subscription modal so users can choose which RSS feed topics they want to subscribe to.

### What's new

- **\NewsletterModal\ component** — modal with email input, per-topic checkboxes, and a 'subscribe to all' toggle. Submits via classic HTML form POST to Mailchimp (avoids CORS on free plan).
- **\NewsletterSettings\ config** — typed \IOptions<>\ class. Feature is **disabled by default** (\Enabled: false\) until Mailchimp is configured.
- **Home page** — sidebar Newsletter link opens the modal instead of a hardcoded URL.
- **Section pages** — newsletter button pre-selects the current section's topic.
- **\SidebarRssLinks\ update** — supports button rendering (null URL + callback).

### To activate after Mailchimp is set up
Set \Newsletter:Enabled: true\ and fill in \FormActionUrl\, \UserId\, \ListId\, and per-topic \GroupId\/\GroupValue\ in production appsettings.

### Tests
- 15 component tests for \NewsletterModal\
- 5 component tests for \SidebarRssLinks\
- All tests pass