### PR TITLE
Track per-subscriber newsletter send status and fix email template compatibility

### DIFF
--- a/docs/admin-authentication.md
+++ b/docs/admin-authentication.md
@@ -121,4 +121,4 @@ These are fed from GitHub Actions secrets → `Deploy-Infrastructure.ps1` env va
 - Token handler — `src/TechHub.Web/Services/AdminTokenDelegatingHandler.cs`
 - Entra ID management — `scripts/Manage-EntraId.ps1` (create + rotate for all environments)
 - Bicep modules — `infra/modules/web.bicep`, `infra/modules/api.bicep`
-- CI/CD secrets — `.github/workflows/ci-cd.yml`
+- CI/CD secrets — `.github/workflows/ci.yml`, `.github/workflows/cd.yml`

--- a/docs/ci-cd-pipeline.md
+++ b/docs/ci-cd-pipeline.md
@@ -286,7 +286,7 @@ Configure these per-environment in GitHub repository settings → Environments �
 | Secret | Staging | Production | Notes |
 |--------|---------|------------|-------|
 | `POSTGRES_ADMIN_PASSWORD` | - | Required | Production DB admin password. `Deploy-Infrastructure.ps1` reads this from Key Vault automatically if not set; only needed explicitly in CI or on first deploy before Key Vault is populated. |
-| `AZURE_AD_CLIENT_SECRET` | - | Required | Entra ID client secret for user authentication — set via `Manage-EntraId.ps1 -Environment prod`. |
+| `AZURE_AD_CLIENT_SECRET` | - | Required | Entra ID client secret for user authentication — set via `Manage-EntraId.ps1 -Environment production`. |
 | `NEWSLETTER_UNSUBSCRIBE_SECRET` | - | Required | HMAC key used to sign newsletter unsubscribe and confirm links. Set once on initial deploy; `Sync-KeyVaultSecrets.ps1` preserves the existing Key Vault value on subsequent deploys if the env var is absent. |
 | `WILDCARD_CERT_HUB_MS` | - | Required | PFX certificate for the `*.hub.ms` wildcard TLS domain. Set once on initial deploy or at renewal time; skipped on re-deploy if already in Key Vault. |
 | `WILDCARD_CERT_XEBIA_MS` | - | Required | PFX certificate for the `*.xebia.ms` wildcard TLS domain. Set once on initial deploy or at renewal time; skipped on re-deploy if already in Key Vault. |

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -194,7 +194,8 @@ Temporary working directory for AI assistants and development tasks (gitignored)
 ### Other Hidden Directories
 
 - **`.github/`** - GitHub Actions workflows and CI/CD automation
-  - `workflows/ci-cd.yml` - Unified CI/CD pipeline: CI (build, test, lint, security) runs on all PRs and pushes; deployment to staging (automatic) and production (manual approval) runs after quality gate passes (PRs skip deployment)
+  - `workflows/ci.yml` - CI pipeline: runs on all pull requests (build, test, lint, security, CodeQL, PR preview deploy/teardown)
+  - `workflows/cd.yml` - CD pipeline: runs on pushes to `main` (CI + staging and production deployment)
   - See [ci-cd-pipeline.md](ci-cd-pipeline.md) for complete CI/CD documentation
 - **`.vscode/`** - VS Code workspace settings and launch configurations
 - **`.git/`** - Git repository metadata

--- a/infra/modules/alerts.bicep
+++ b/infra/modules/alerts.bicep
@@ -33,12 +33,10 @@ param tags object = {}
 var severityHigh = 1
 var severityMedium = 2
 
-// --- Application Insights: failed request count (log query, noise-filtered) ---
-// Excludes:
-//   ResultCode=0  — client-aborted Blazor SignalR circuits and bot connections that
-//                   drop the WebSocket before the server can respond. Always client-side.
-//   HTTP 499      — client closed the connection before the server finished responding.
-//                   Unactionable; spikes during outages are captured by availability tests.
+// --- Application Insights: failed request count (log query) ---
+// Includes all failed requests — ResultCode=0 (client aborted) and HTTP 499 (client
+// closed before response) are intentionally NOT excluded: a burst of either can indicate
+// the application is too slow and users are abandoning requests, which is actionable.
 // Scoped to the App Insights resource (not the Log Analytics workspace) so that the
 // 'requests' table is always available during ARM KQL schema validation.
 resource failedRequestsAlert 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
@@ -47,7 +45,7 @@ resource failedRequestsAlert 'Microsoft.Insights/scheduledQueryRules@2023-03-15-
   tags: tags
   properties: {
     displayName: 'Failed HTTP requests (${environmentName})'
-    description: 'Fires when actionable failed requests exceed 10 in 15 minutes. Excludes ResultCode=0 (client-aborted) and HTTP 499 (client disconnect).'
+    description: 'Fires when failed requests exceed 10 in 15 minutes, including client disconnects (499) and aborted circuits (0) which may indicate the application is too slow.'
     severity: severityHigh
     enabled: true
     evaluationFrequency: 'PT5M'
@@ -56,7 +54,7 @@ resource failedRequestsAlert 'Microsoft.Insights/scheduledQueryRules@2023-03-15-
     criteria: {
       allOf: [
         {
-          query: 'requests\n| where success == false\n| where resultCode != "0"\n| where resultCode != "499"'
+          query: 'requests\n| where success == false'
           timeAggregation: 'Count'
           operator: 'GreaterThan'
           threshold: 10

--- a/infra/parameters/prod-applications.bicepparam
+++ b/infra/parameters/prod-applications.bicepparam
@@ -23,8 +23,8 @@ param openAiName = 'oai-techhub-prod'
 // Azure AD — admin dashboard authentication
 // Tenant ID and Client ID are public Entra identifiers (issuer URL contains tenant ID).
 // The actual Client Secret lives in Key Vault — see scripts/Sync-KeyVaultSecrets.ps1.
-param azureAdTenantId = '3d4d17ea-1ae4-4705-947e-51369c5a5f79'
-param azureAdClientId = '6f993c39-347a-49a2-a854-836d07358905'
+param azureAdTenantId = '459df0d4-819b-42e9-9ff4-f9ddf3065c0c'
+param azureAdClientId = '03886f87-2316-4ee8-ba3b-353cfcb43f4c'
 // GitHub Container Registry
 param githubRegistryUsername = 'techhubms'
 // Telemetry — set to empty string in PR preview environments to prevent data from

--- a/scripts/Manage-EntraId.ps1
+++ b/scripts/Manage-EntraId.ps1
@@ -20,9 +20,10 @@
     3. Optionally cleans up expired secrets
 
     Deployment SP Key Vault roles (staging/production only):
-    The GitHub Actions deployment service principal (AZURE_CREDENTIALS) is separate from the
-    TechHub OIDC app registration. It needs two roles on the subscription to write secrets and
-    manage Key Vault network firewall rules during deploy:
+    The GitHub Actions deployment service principal (sp-techhubms, appId: 91fe5f39-bee3-48b1-b976-e8ba4e41d84e)
+    is separate from the TechHub OIDC app registration. It uses OIDC federated credentials (no secret)
+    and needs two roles on the subscription to write secrets and manage Key Vault network firewall rules
+    during deploy:
         - Key Vault Secrets Officer  (write/read/delete secrets)
         - Key Vault Contributor      (manage network ACL rules)
     Pass -DeploymentSpObjectId <OID> to assign these roles automatically.
@@ -60,7 +61,7 @@
     GitHub repository in 'owner/repo' format. Defaults to the current repo.
 
 .PARAMETER DeploymentSpObjectId
-    Object ID of the GitHub Actions deployment service principal (from AZURE_CREDENTIALS).
+    Object ID of the GitHub Actions deployment service principal (sp-techhubms).
     When provided for staging/production, assigns 'Key Vault Secrets Officer' and
     'Key Vault Contributor' roles at subscription scope. Safe to re-run (idempotent).
 

--- a/scripts/Setup-OidcAuthentication.ps1
+++ b/scripts/Setup-OidcAuthentication.ps1
@@ -17,7 +17,7 @@
     The pull_request subject covers PR preview jobs that have no GitHub environment assigned
     (pr-preview-build-and-push, pr-preview-teardown), including Dependabot PRs.
 
-    After running this script, delete the AZURE_CREDENTIALS GitHub secret - it is no longer used.
+    After running this script, ensure no AZURE_CREDENTIALS secret exists in GitHub - it is not used.
 
     Requires:
       - Azure CLI (az) authenticated with permission to manage app registrations
@@ -40,7 +40,7 @@
 
 param(
     [Parameter(Mandatory = $false)]
-    [string]$AppId = 'b515cadd-924c-4a87-ad8d-4fb41ed8b85b',
+    [string]$AppId = '91fe5f39-bee3-48b1-b976-e8ba4e41d84e',
 
     [Parameter(Mandatory = $false)]
     [string]$GitHubRepo = 'techhubms/techhub'
@@ -214,7 +214,5 @@ foreach ($varName in $variables.Keys) {
 Write-Host ""
 Write-Host "OIDC setup complete." -ForegroundColor Green
 Write-Host ""
-Write-Host "Next step: delete the AZURE_CREDENTIALS secret from GitHub." -ForegroundColor Yellow
-Write-Host "  Go to: https://github.com/$GitHubRepo/settings/secrets/actions" -ForegroundColor Yellow
-Write-Host "  Delete: AZURE_CREDENTIALS" -ForegroundColor Yellow
+Write-Host "OIDC is the only authentication method — no AZURE_CREDENTIALS secret is needed." -ForegroundColor Green
 Write-Host ""

--- a/src/TechHub.Core/Interfaces/INewsletterSubscriberRepository.cs
+++ b/src/TechHub.Core/Interfaces/INewsletterSubscriberRepository.cs
@@ -59,5 +59,7 @@ public interface INewsletterSubscriberRepository
 
     Task<IReadOnlyList<NewsletterSendLogEntry>> GetSendLogAsync(int count = 100, CancellationToken ct = default);
 
+    Task RecordSubscriberSendAsync(string email, bool isWeekly, bool succeeded, CancellationToken ct = default);
+
     Task<NewsletterDailyReportStats> GetDailyReportStatsAsync(CancellationToken ct = default);
 }

--- a/src/TechHub.Core/Models/NewsletterSubscriber.cs
+++ b/src/TechHub.Core/Models/NewsletterSubscriber.cs
@@ -10,4 +10,8 @@ public sealed class NewsletterSubscriber
     public DateTimeOffset? ConfirmedAt { get; init; }
     public IReadOnlyList<string> WeeklySections { get; init; } = [];
     public IReadOnlyList<string> DailySections { get; init; } = [];
+    public DateTimeOffset? LastDailySentAt { get; init; }
+    public bool? LastDailySucceeded { get; init; }
+    public DateTimeOffset? LastWeeklySentAt { get; init; }
+    public bool? LastWeeklySucceeded { get; init; }
 }

--- a/src/TechHub.Infrastructure/Data/Migrations/postgres/047_newsletter_subscriber_send_status.sql
+++ b/src/TechHub.Infrastructure/Data/Migrations/postgres/047_newsletter_subscriber_send_status.sql
@@ -1,0 +1,5 @@
+ALTER TABLE newsletter_subscribers
+    ADD COLUMN IF NOT EXISTS last_daily_sent_at   TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS last_daily_succeeded  BOOLEAN,
+    ADD COLUMN IF NOT EXISTS last_weekly_sent_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS last_weekly_succeeded BOOLEAN;

--- a/src/TechHub.Infrastructure/Data/Resources/newsletter-daily-content.html
+++ b/src/TechHub.Infrastructure/Data/Resources/newsletter-daily-content.html
@@ -1,6 +1,6 @@
-<p class="th-date" style="margin:0 0 20px 0;font-size:15px;color:#4a5568;font-weight:500;text-decoration:underline;">{{date}}</p>
+<p class="th-section-label">{{date}}</p>
 {{#each sections}}
-<h3 class="th-section-heading">{{title}}</h3>
+<h3 class="th-section-heading"{{#if @first}} style="margin-top: 8px;"{{/if}}>{{title}}</h3>
 <ul class="th-item-list">
   {{#each items}}
   <li class="th-item">

--- a/src/TechHub.Infrastructure/Data/Resources/newsletter-daily-content.html
+++ b/src/TechHub.Infrastructure/Data/Resources/newsletter-daily-content.html
@@ -1,4 +1,3 @@
-<p class="th-section-label">{{date}}</p>
 {{#each sections}}
 <h3 class="th-section-heading"{{#if @first}} style="margin-top: 8px;"{{/if}}>{{title}}</h3>
 <ul class="th-item-list">

--- a/src/TechHub.Infrastructure/Data/Resources/newsletter-subscriber-footer.html
+++ b/src/TechHub.Infrastructure/Data/Resources/newsletter-subscriber-footer.html
@@ -1,4 +1,4 @@
-<p class="th-footer" style="margin:28px 0 0 0;font-size:12px;color:#4a5568;border-top:1px solid #e8d9ff;padding-top:20px;">
+<p class="th-footer" style="margin:28px 0 0 0;font-size:12px;color:#4a5568;border-top:2px solid #6b7280;padding-top:8px;">
   You received this because you subscribed to TechHub newsletters.<br />
   <a href="{{manageUrl}}" class="th-link" style="color:#6535c7;text-decoration:none;font-weight:500;">Manage subscription</a> &nbsp;·&nbsp;
   <a href="{{unsubscribeUrl}}" class="th-link" style="color:#6535c7;text-decoration:none;font-weight:500;">Unsubscribe</a>

--- a/src/TechHub.Infrastructure/Data/Resources/newsletter-template.html
+++ b/src/TechHub.Infrastructure/Data/Resources/newsletter-template.html
@@ -1,63 +1,111 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="color-scheme" content="light dark" />
-  <meta name="supported-color-schemes" content="light dark" />
-  <style>
-    .th-body { margin:0; padding:0; font-family:Segoe UI,Arial,sans-serif; }
-    .th-outer { padding:20px 8px; }
-    .th-card { background-color:#ffffff; border-radius:12px; box-shadow:0 2px 12px rgba(137,87,229,0.10); }
-    .th-card--weekly { max-width:900px; }
-    .th-card--daily { max-width:1100px; }
-    .th-card--admin { max-width:600px; }
-    .th-card--account { max-width:640px; }
-    .th-header { background-color:#ede5ff; color:#1f2328; padding:24px 28px; font-size:20px; font-weight:700; border-top:1px solid #a87ee8; border-left:1px solid #a87ee8; border-right:1px solid #a87ee8; border-bottom:1px solid #a87ee8; border-top-left-radius:12px; border-top-right-radius:12px; }
-    .th-content { background-color:#ffffff; color:#1f2328; padding:28px; border-left:1px solid #a87ee8; border-right:1px solid #a87ee8; border-bottom:1px solid #a87ee8; border-bottom-left-radius:12px; border-bottom-right-radius:12px; }
-    .th-date { margin:0 0 20px 0; font-size:15px; color:#4a5568; font-weight:500; }
-    .th-divider { border:none; border-top:1px solid #e8d9ff; margin:28px 0; }
-    .th-section-label { margin:0 0 4px 0; font-size:12px; font-weight:600; letter-spacing:0.05em; text-transform:uppercase; color:#4a5568; }
-    .th-roundup-title { margin:0 0 12px 0; font-size:22px; color:#1f2328; }
-    .th-roundup-intro { margin:0 0 16px 0; line-height:1.6; color:#1f2328; }
-    .th-subtitle { margin:0 0 8px 0; font-size:15px; color:#1f2328; font-weight:600; }
-    .th-links-wrap { margin:0 0 16px 0; }
-    .th-list { padding-left:18px; margin:0; }
-    .th-list-item { margin:0 0 8px 0; color:#1f2328; font-size:14px; }
-    .th-section-heading { margin:20px 0 8px 0; font-size:18px; font-weight:700; color:#1f2328; }
-    .th-item-list { margin:0 0 8px 0; padding-left:20px; }
-    .th-item { margin-bottom:6px; font-size:16px; line-height:1.5; color:#1f2328; }
-    .th-stat-label { padding:8px 0; color:#4a5568; font-size:14px; }
-    .th-stat-value { padding:8px 0; color:#1f2328; font-size:14px; text-align:right; font-weight:600; }
-    .th-stat-border { border-bottom:1px solid #e8d9ff; }
-    .th-heading { margin:0 0 12px 0; color:#1f2328; font-size:24px; }
-    .th-body-text { margin:0 0 16px 0; line-height:1.5; color:#1f2328; }
-    .th-note { margin:0; color:#4a5568; font-size:14px; line-height:1.5; }
-    .th-link { color:#6535c7 !important; text-decoration:none; font-weight:500; }
-    .th-muted { color:#4a5568; font-size:14px; }
-    .th-cta-wrap { margin:0; }
-    .th-button-cell { border:2px solid #6535c7; border-radius:6px; padding:9px 18px; }
-    .th-button { color:#6535c7 !important; text-decoration:none; font-weight:600; font-size:16px; }
-    .th-footer { margin:28px 0 0 0; font-size:12px; color:#4a5568; border-top:1px solid #e8d9ff; padding-top:20px; }
+<html lang="en" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no" />
+    <meta name="color-scheme" content="light" />
+    <meta name="supported-color-schemes" content="light" />
+    <!--[if gte mso 9]><xml>
+      <o:OfficeDocumentSettings>
+        <o:AllowPNG/>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml><![endif]-->
+    <!--[if mso]><style>* { font-family: sans-serif !important; }</style><![endif]-->
+    <style>
+      /* ── CSS Reset ─────────────────────────────────────────── */
+      :root { color-scheme: light only; supported-color-schemes: light; }
+      html, body { margin: 0 auto !important; padding: 0 !important; height: 100% !important; width: 100% !important; }
+      * { -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; }
+      div[style*="margin: 16px 0"] { margin: 0 !important; }
+      #MessageViewBody, #MessageWebViewDiv { width: 100% !important; }
+      table, td { mso-table-lspace: 0pt !important; mso-table-rspace: 0pt !important; }
+      table { border-spacing: 0 !important; border-collapse: collapse !important; table-layout: fixed !important; margin: 0 auto !important; }
+      img { -ms-interpolation-mode: bicubic; }
+      a { text-decoration: none; }
+      a[x-apple-data-detectors], .unstyle-auto-detected-links a, .aBn {
+        border-bottom: 0 !important; cursor: default !important; color: inherit !important;
+        text-decoration: none !important; font-size: inherit !important; font-family: inherit !important;
+        font-weight: inherit !important; line-height: inherit !important;
+      }
+      .im { color: inherit !important; }
 
-  </style>
-</head>
-<body class="th-body" style="margin:0;padding:0;font-family:Segoe UI,Arial,sans-serif;">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
-    <tr>
-      <td align="center" class="th-outer" style="padding:20px 8px;">
-          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" class="th-card {{cardClass}}" bgcolor="#ffffff" style="max-width:{{maxWidth}};background-color:#ffffff;border-radius:12px;">
-          <tr>
-            <td bgcolor="#ede5ff" class="th-header" style="background-color:#ede5ff;color:#1f2328;padding:24px 28px;font-size:20px;font-weight:700;border-top:1px solid #a87ee8;border-left:1px solid #a87ee8;border-right:1px solid #a87ee8;border-bottom:1px solid #a87ee8;border-top-left-radius:12px;border-top-right-radius:12px;">{{title}}</td>
-          </tr>
-          <tr>
-            <td bgcolor="#ffffff" class="th-content" style="background-color:#ffffff;color:#1f2328;padding:28px;border-left:1px solid #a87ee8;border-right:1px solid #a87ee8;border-bottom:1px solid #a87ee8;border-bottom-left-radius:12px;border-bottom-right-radius:12px;">
-              {{{content}}}
-            </td>
-          </tr>
+      /* ── TechHub Light Mode Styles ─────────────────────────── */
+      .th-header {
+        font-family: Segoe UI, Arial, sans-serif;
+        font-size: 24px;
+        font-weight: 700;
+        color: #6535c7;
+        border-bottom: 2px solid #e8d9ff;
+        padding: 16px 0;
+        margin-bottom: 8px;
+      }
+      .th-content {
+        font-family: Segoe UI, Arial, sans-serif;
+        font-size: 16px;
+        line-height: 1.6;
+        color: #1f2328;
+      }
+      .th-link { color: #6535c7 !important; text-decoration: none; font-weight: 500; }
+      .th-button { color: #6535c7 !important; text-decoration: none; font-weight: 600; font-size: 16px; white-space: nowrap; }
+      .th-button-cell { border: 2px solid #6535c7; border-radius: 6px; padding: 9px 18px; }
+      .th-divider { border: 0; height: 1px; background: #e8d9ff; color: #e8d9ff; margin: 24px 0; }
+      .th-section-label {
+        display: inline-block;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: #6535c7;
+        border: 1px solid #6535c7;
+        border-radius: 3px;
+        padding: 2px 6px;
+        margin-bottom: 8px;
+      }
+      .th-roundup-title { font-size: 20px; font-weight: 600; color: #1f2328; margin: 8px 0; }
+      .th-roundup-intro { color: #57606a; margin: 8px 0 16px; }
+      .th-subtitle { font-size: 15px; font-weight: 600; color: #1f2328; margin: 16px 0 8px; }
+      .th-section-heading { font-size: 18px; font-weight: 600; color: #1f2328; margin: 24px 0 12px; }
+      .th-muted { color: #57606a; font-size: 14px; }
+      .th-footer { font-size: 12px; color: #4a5568; border-top: 1px solid #e8d9ff; padding-top: 20px; margin-top: 28px; }
+    </style>
+  </head>
+
+  <body width="100%" bgcolor="#ffffff" class="th-bg" style="margin: 0; padding: 0 !important; mso-line-height-rule: exactly; background-color: #ffffff;">
+    <center role="article" aria-roledescription="email" lang="en" class="th-bg" style="width: 100%; background-color: #ffffff;">
+      <!--[if mso | IE]>
+      <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tr><td>
+      <![endif]-->
+      <div style="max-width: 640px; margin: 0 auto;" class="email-container">
+        <!--[if mso]>
+        <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="640">
+        <tr><td>
+        <![endif]-->
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" bgcolor="#ffffff" style="margin: auto; background-color: #ffffff;">
+          <tbody>
+            <tr>
+              <td class="th-bg" bgcolor="#ffffff" style="padding: 24px 40px 0 40px; background-color: #ffffff;">
+                <div class="th-header">{{title}}</div>
+              </td>
+            </tr>
+            <tr>
+              <td class="th-bg" bgcolor="#ffffff" style="padding: 4px 40px 40px 40px; background-color: #ffffff;">
+                <div class="th-content">{{{content}}}</div>
+              </td>
+            </tr>
+          </tbody>
         </table>
-      </td>
-    </tr>
-  </table>
-</body>
+        <!--[if mso]>
+        </td></tr></table>
+        <![endif]-->
+      </div>
+      <!--[if mso | IE]>
+      </td></tr></table>
+      <![endif]-->
+    </center>
+  </body>
 </html>

--- a/src/TechHub.Infrastructure/Data/Resources/newsletter-template.html
+++ b/src/TechHub.Infrastructure/Data/Resources/newsletter-template.html
@@ -22,6 +22,11 @@
       * { -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; }
       div[style*="margin: 16px 0"] { margin: 0 !important; }
       #MessageViewBody, #MessageWebViewDiv { width: 100% !important; }
+
+      /* ── Responsive ────────────────────────────────────────── */
+      @media only screen and (max-width: 480px) {
+        .email-container { width: 100% !important; padding: 0 8px !important; box-sizing: border-box; }
+      }
       table, td { mso-table-lspace: 0pt !important; mso-table-rspace: 0pt !important; }
       table { border-spacing: 0 !important; border-collapse: collapse !important; table-layout: fixed !important; margin: 0 auto !important; }
       img { -ms-interpolation-mode: bicubic; }
@@ -39,9 +44,8 @@
         font-size: 24px;
         font-weight: 700;
         color: #6535c7;
-        border-bottom: 2px solid #e8d9ff;
-        padding: 16px 0;
-        margin-bottom: 8px;
+        padding: 16px 0 0;
+        margin-bottom: 0;
       }
       .th-content {
         font-family: Segoe UI, Arial, sans-serif;
@@ -80,9 +84,9 @@
       <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr><td>
       <![endif]-->
-      <div style="max-width: 640px; margin: 0 auto;" class="email-container">
+      <div style="width: 80%; max-width: 1024px; margin: 0 auto;" class="email-container">
         <!--[if mso]>
-        <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="640">
+        <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="1024">
         <tr><td>
         <![endif]-->
         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" bgcolor="#ffffff" style="margin: auto; background-color: #ffffff;">

--- a/src/TechHub.Infrastructure/Data/Resources/newsletter-weekly-content.html
+++ b/src/TechHub.Infrastructure/Data/Resources/newsletter-weekly-content.html
@@ -1,7 +1,7 @@
 {{#each roundups}}
 {{#unless @first}}<hr class="th-divider" />{{/unless}}
 <div class="th-roundup">
-  <p class="th-section-label" style="text-decoration:underline;">{{sectionTitle}}</p>
+  <p class="th-section-label">{{sectionTitle}}</p>
   <h2 class="th-roundup-title">{{title}}</h2>
   <p class="th-roundup-intro">{{introduction}}</p>
   <h3 class="th-subtitle">In this roundup</h3>
@@ -16,7 +16,7 @@
     <table role="presentation" cellpadding="0" cellspacing="0">
       <tr>
         <td class="th-button-cell" style="border:2px solid #6535c7;border-radius:6px;padding:9px 18px;">
-          <a href="{{roundupUrl}}" class="th-button" style="color:#6535c7;text-decoration:none;font-weight:600;font-size:16px;white-space:nowrap;">📑 Read the full {{sectionTitle}} roundup &#x2192;</a>
+          <a href="{{roundupUrl}}" class="th-button" style="color:#6535c7;text-decoration:none;font-weight:600;font-size:16px;white-space:nowrap;">📑 Read the full {{sectionTag}} roundup &#x2192;</a>
         </td>
       </tr>
     </table>

--- a/src/TechHub.Infrastructure/Repositories/NewsletterSubscriberRepository.cs
+++ b/src/TechHub.Infrastructure/Repositories/NewsletterSubscriberRepository.cs
@@ -193,7 +193,11 @@ public sealed class NewsletterSubscriberRepository : INewsletterSubscriberReposi
                 is_confirmed AS IsConfirmed,
                 subscribed_at AS SubscribedAt,
                 confirmed_at AS ConfirmedAt,
-                preferences::text AS Preferences
+                preferences::text AS Preferences,
+                last_daily_sent_at AS LastDailySentAt,
+                last_daily_succeeded AS LastDailySucceeded,
+                last_weekly_sent_at AS LastWeeklySentAt,
+                last_weekly_succeeded AS LastWeeklySucceeded
             FROM newsletter_subscribers
             WHERE {whereSql}
             ORDER BY subscribed_at DESC, id DESC
@@ -344,7 +348,11 @@ public sealed class NewsletterSubscriberRepository : INewsletterSubscriberReposi
                 is_confirmed AS IsConfirmed,
                 subscribed_at AS SubscribedAt,
                 confirmed_at AS ConfirmedAt,
-                preferences::text AS Preferences
+                preferences::text AS Preferences,
+                last_daily_sent_at AS LastDailySentAt,
+                last_daily_succeeded AS LastDailySucceeded,
+                last_weekly_sent_at AS LastWeeklySentAt,
+                last_weekly_succeeded AS LastWeeklySucceeded
             FROM newsletter_subscribers
             WHERE lower(email) = lower(@Email)
               AND unsubscribed_at IS NULL
@@ -390,6 +398,30 @@ public sealed class NewsletterSubscriberRepository : INewsletterSubscriberReposi
         return affected > 0;
     }
 
+    public async Task RecordSubscriberSendAsync(string email, bool isWeekly, bool succeeded, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(email);
+
+        await _connection.ExecuteAsync(new CommandDefinition(
+            isWeekly
+                ? """
+                    UPDATE newsletter_subscribers
+                    SET last_weekly_sent_at  = NOW(),
+                        last_weekly_succeeded = @Succeeded
+                    WHERE lower(email) = lower(@Email)
+                      AND unsubscribed_at IS NULL
+                    """
+                : """
+                    UPDATE newsletter_subscribers
+                    SET last_daily_sent_at  = NOW(),
+                        last_daily_succeeded = @Succeeded
+                    WHERE lower(email) = lower(@Email)
+                      AND unsubscribed_at IS NULL
+                    """,
+            new { Email = email.Trim(), Succeeded = succeeded },
+            cancellationToken: ct));
+    }
+
     public async Task<NewsletterDailyReportStats> GetDailyReportStatsAsync(CancellationToken ct = default)
     {
         const string Sql = """
@@ -418,7 +450,11 @@ public sealed class NewsletterSubscriberRepository : INewsletterSubscriberReposi
             SubscribedAt = row.SubscribedAt,
             ConfirmedAt = row.ConfirmedAt,
             WeeklySections = preferences.WeeklySections,
-            DailySections = preferences.DailySections
+            DailySections = preferences.DailySections,
+            LastDailySentAt = row.LastDailySentAt,
+            LastDailySucceeded = row.LastDailySucceeded,
+            LastWeeklySentAt = row.LastWeeklySentAt,
+            LastWeeklySucceeded = row.LastWeeklySucceeded
         };
     }
 
@@ -472,6 +508,10 @@ public sealed class NewsletterSubscriberRepository : INewsletterSubscriberReposi
         public DateTimeOffset SubscribedAt { get; init; }
         public DateTimeOffset? ConfirmedAt { get; init; }
         public string? Preferences { get; init; }
+        public DateTimeOffset? LastDailySentAt { get; init; }
+        public bool? LastDailySucceeded { get; init; }
+        public DateTimeOffset? LastWeeklySentAt { get; init; }
+        public bool? LastWeeklySucceeded { get; init; }
     }
 
     private sealed class SubscriberPreferences

--- a/src/TechHub.Infrastructure/Services/Newsletter/NewsletterService.cs
+++ b/src/TechHub.Infrastructure/Services/Newsletter/NewsletterService.cs
@@ -137,15 +137,19 @@ public sealed class NewsletterService : INewsletterService
                 var html = RenderCombinedWeeklyHtml(relevantRoundups, unsubscribeUrl, manageUrl);
                 var text = BuildCombinedWeeklyPlainText(relevantRoundups, unsubscribeUrl, manageUrl);
 
-                if (await SendEmailAsync(subscriber.Email, subject, html, text, ct))
+                var emailSent = await SendEmailAsync(subscriber.Email, subject, html, text, ct);
+                if (emailSent)
                 {
                     successful++;
                 }
+
+                await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: true, succeeded: emailSent, ct);
             }
 #pragma warning disable CA1031 // Best-effort: continue with other subscribers if one fails
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogWarning(ex, "Failed sending weekly newsletter to subscriber — skipping");
+                await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: true, succeeded: false, CancellationToken.None);
             }
 #pragma warning restore CA1031
         }
@@ -409,10 +413,13 @@ public sealed class NewsletterService : INewsletterService
 
             var html = BuildDailyOverviewHtml(day, selectedSections, itemsBySection, subscriber.Email);
             var text = BuildDailyOverviewText(day, selectedSections, itemsBySection, subscriber.Email);
-            if (await SendEmailAsync(subscriber.Email, $"TechHub Daily Overview — {targetKey}", html, text, ct))
+            var emailSent = await SendEmailAsync(subscriber.Email, $"TechHub Daily Overview — {targetKey}", html, text, ct);
+            if (emailSent)
             {
                 sent++;
             }
+
+            await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: false, succeeded: emailSent, ct);
         }
 
         var sendStatus = eligible == 0 || sent == eligible ? "sent" : sent > 0 ? "partial" : "failed";
@@ -440,6 +447,16 @@ public sealed class NewsletterService : INewsletterService
         }
 
         var stats = await _subscriberRepository.GetDailyReportStatsAsync(ct);
+
+        var hasFailures = stats.FailedProcessedUrlsLast24Hours > 0
+            || stats.FailedJobsLast24Hours > 0
+            || stats.FailedNewsletterSendsLast24Hours > 0;
+
+        if (!hasFailures)
+        {
+            return false;
+        }
+
         var html = BuildAdminStatusHtml(day, stats);
         var text = BuildAdminStatusText(day, stats);
 
@@ -661,6 +678,7 @@ public sealed class NewsletterService : INewsletterService
                     Title = row.Title,
                     CollectionName = row.CollectionName
                 })
+                .OrderBy(row => row.Title, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
 
@@ -690,6 +708,7 @@ public sealed class NewsletterService : INewsletterService
             roundups = roundups.Select(r => new
             {
                 sectionTitle = GetSectionTitle(r.SectionName),
+                sectionTag = GetSectionTag(r.SectionName),
                 title = StripRoundupPrefix(r.Title),
                 introduction = r.Introduction,
                 roundupUrl = BuildAbsoluteUrl($"/{r.SectionName}/roundups/{r.Slug}"),
@@ -735,6 +754,9 @@ public sealed class NewsletterService : INewsletterService
 
     private string GetSectionTitle(string slug) =>
         _appSettings.Content.Sections.TryGetValue(slug, out var config) ? config.Title : slug;
+
+    private string GetSectionTag(string slug) =>
+        _appSettings.Content.Sections.TryGetValue(slug, out var config) ? config.Tag : slug;
 
     private static string StripRoundupPrefix(string title)
     {

--- a/src/TechHub.Infrastructure/Services/Newsletter/NewsletterService.cs
+++ b/src/TechHub.Infrastructure/Services/Newsletter/NewsletterService.cs
@@ -171,7 +171,6 @@ public sealed class NewsletterService : INewsletterService
 #pragma warning restore CA1031
             }
 #pragma warning restore CA1031
-#pragma warning restore CA1031
         }
 
         var sendStatus = attempted == 0 || successful == attempted ? "sent" : successful > 0 ? "partial" : "failed";

--- a/src/TechHub.Infrastructure/Services/Newsletter/NewsletterService.cs
+++ b/src/TechHub.Infrastructure/Services/Newsletter/NewsletterService.cs
@@ -143,32 +143,13 @@ public sealed class NewsletterService : INewsletterService
                     successful++;
                 }
 
-                try
-                {
-                    await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: true, succeeded: emailSent, ct);
-                }
-#pragma warning disable CA1031 // Best-effort: send-status tracking must not abort subscriber sending
-                catch (Exception ex) when (ex is not OperationCanceledException)
-                {
-                    _logger.LogWarning(ex, "Failed recording weekly newsletter send status for subscriber — skipping");
-                }
-#pragma warning restore CA1031
+                await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: true, succeeded: emailSent, ct);
             }
 #pragma warning disable CA1031 // Best-effort: continue with other subscribers if one fails
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogWarning(ex, "Failed sending weekly newsletter to subscriber — skipping");
-
-                try
-                {
-                    await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: true, succeeded: false, ct);
-                }
-#pragma warning disable CA1031 // Best-effort: send-status tracking must not abort subscriber sending
-                catch (Exception recordEx) when (recordEx is not OperationCanceledException)
-                {
-                    _logger.LogWarning(recordEx, "Failed recording weekly newsletter send status for subscriber — skipping");
-                }
-#pragma warning restore CA1031
+                await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: true, succeeded: false, CancellationToken.None);
             }
 #pragma warning restore CA1031
         }
@@ -430,15 +411,25 @@ public sealed class NewsletterService : INewsletterService
             eligible++;
             selectedSections = OrderSectionsByWebsiteOrder(selectedSections);
 
-            var html = BuildDailyOverviewHtml(day, selectedSections, itemsBySection, subscriber.Email);
-            var text = BuildDailyOverviewText(day, selectedSections, itemsBySection, subscriber.Email);
-            var emailSent = await SendEmailAsync(subscriber.Email, $"TechHub Daily Overview — {targetKey}", html, text, ct);
-            if (emailSent)
+            try
             {
-                sent++;
-            }
+                var html = BuildDailyOverviewHtml(day, selectedSections, itemsBySection, subscriber.Email);
+                var text = BuildDailyOverviewText(day, selectedSections, itemsBySection, subscriber.Email);
+                var emailSent = await SendEmailAsync(subscriber.Email, $"TechHub Daily Overview — {targetKey}", html, text, ct);
+                if (emailSent)
+                {
+                    sent++;
+                }
 
-            await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: false, succeeded: emailSent, ct);
+                await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: false, succeeded: emailSent, ct);
+            }
+#pragma warning disable CA1031 // Best-effort: continue with other subscribers if one fails
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Failed sending daily newsletter to subscriber — skipping");
+                await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: false, succeeded: false, CancellationToken.None);
+            }
+#pragma warning restore CA1031
         }
 
         var sendStatus = eligible == 0 || sent == eligible ? "sent" : sent > 0 ? "partial" : "failed";

--- a/src/TechHub.Infrastructure/Services/Newsletter/NewsletterService.cs
+++ b/src/TechHub.Infrastructure/Services/Newsletter/NewsletterService.cs
@@ -143,14 +143,34 @@ public sealed class NewsletterService : INewsletterService
                     successful++;
                 }
 
-                await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: true, succeeded: emailSent, ct);
+                try
+                {
+                    await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: true, succeeded: emailSent, ct);
+                }
+#pragma warning disable CA1031 // Best-effort: send-status tracking must not abort subscriber sending
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex, "Failed recording weekly newsletter send status for subscriber — skipping");
+                }
+#pragma warning restore CA1031
             }
 #pragma warning disable CA1031 // Best-effort: continue with other subscribers if one fails
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogWarning(ex, "Failed sending weekly newsletter to subscriber — skipping");
-                await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: true, succeeded: false, CancellationToken.None);
+
+                try
+                {
+                    await _subscriberRepository.RecordSubscriberSendAsync(subscriber.Email, isWeekly: true, succeeded: false, ct);
+                }
+#pragma warning disable CA1031 // Best-effort: send-status tracking must not abort subscriber sending
+                catch (Exception recordEx) when (recordEx is not OperationCanceledException)
+                {
+                    _logger.LogWarning(recordEx, "Failed recording weekly newsletter send status for subscriber — skipping");
+                }
+#pragma warning restore CA1031
             }
+#pragma warning restore CA1031
 #pragma warning restore CA1031
         }
 

--- a/src/TechHub.Infrastructure/Services/Newsletter/NewsletterService.cs
+++ b/src/TechHub.Infrastructure/Services/Newsletter/NewsletterService.cs
@@ -833,7 +833,7 @@ public sealed class NewsletterService : INewsletterService
         });
         return _templates.Shell(new
         {
-            title = "TechHub Daily Overview",
+            title = $"TechHub Daily Overview — {day.ToString("d MMMM yyyy", CultureInfo.InvariantCulture)}",
             cardClass = "th-card--daily",
             maxWidth = "1100px",
             content

--- a/src/TechHub.Infrastructure/Services/Newsletter/NewsletterTemplateProvider.cs
+++ b/src/TechHub.Infrastructure/Services/Newsletter/NewsletterTemplateProvider.cs
@@ -11,35 +11,60 @@ namespace TechHub.Infrastructure.Services.Newsletter;
 /// </summary>
 public sealed class NewsletterTemplateProvider
 {
-    public HandlebarsTemplate<object, object> Shell { get; }
-    public HandlebarsTemplate<object, object> SubscriberFooter { get; }
-    public HandlebarsTemplate<object, object> AccountAction { get; }
-    public HandlebarsTemplate<object, object> WeeklyContent { get; }
-    public HandlebarsTemplate<object, object> DailyContent { get; }
-    public HandlebarsTemplate<object, object> AdminContent { get; }
+    private readonly IHostEnvironment _env;
+    private readonly string _resourcesPath = string.Empty;
+
+    // Cache compiled templates for production performance
+#pragma warning disable IDE0032
+    private readonly HandlebarsTemplate<object, object>? _shell;
+    private readonly HandlebarsTemplate<object, object>? _subscriberFooter;
+    private readonly HandlebarsTemplate<object, object>? _accountAction;
+    private readonly HandlebarsTemplate<object, object>? _weeklyContent;
+    private readonly HandlebarsTemplate<object, object>? _dailyContent;
+    private readonly HandlebarsTemplate<object, object>? _adminContent;
+#pragma warning restore IDE0032
+
+    public HandlebarsTemplate<object, object> Shell => _env.IsDevelopment()
+        ? Handlebars.Compile(File.ReadAllText(Path.Join(_resourcesPath, "newsletter-template.html")))
+        : _shell!;
+
+    public HandlebarsTemplate<object, object> SubscriberFooter => _env.IsDevelopment()
+        ? Handlebars.Compile(File.ReadAllText(Path.Join(_resourcesPath, "newsletter-subscriber-footer.html")))
+        : _subscriberFooter!;
+
+    public HandlebarsTemplate<object, object> AccountAction => _env.IsDevelopment()
+        ? Handlebars.Compile(File.ReadAllText(Path.Join(_resourcesPath, "newsletter-account-action-content.html")))
+        : _accountAction!;
+
+    public HandlebarsTemplate<object, object> WeeklyContent => _env.IsDevelopment()
+        ? Handlebars.Compile(File.ReadAllText(Path.Join(_resourcesPath, "newsletter-weekly-content.html")))
+        : _weeklyContent!;
+
+    public HandlebarsTemplate<object, object> DailyContent => _env.IsDevelopment()
+        ? Handlebars.Compile(File.ReadAllText(Path.Join(_resourcesPath, "newsletter-daily-content.html")))
+        : _dailyContent!;
+
+    public HandlebarsTemplate<object, object> AdminContent => _env.IsDevelopment()
+        ? Handlebars.Compile(File.ReadAllText(Path.Join(_resourcesPath, "newsletter-admin-content.html")))
+        : _adminContent!;
 
     public NewsletterTemplateProvider(IHostEnvironment env)
     {
         ArgumentNullException.ThrowIfNull(env);
+        _env = env;
 
         if (env.IsDevelopment())
         {
-            var resourcesPath = Path.GetFullPath(Path.Join(env.ContentRootPath, "..", "TechHub.Infrastructure", "Data", "Resources"));
-            Shell = Handlebars.Compile(File.ReadAllText(Path.Join(resourcesPath, "newsletter-template.html")));
-            SubscriberFooter = Handlebars.Compile(File.ReadAllText(Path.Join(resourcesPath, "newsletter-subscriber-footer.html")));
-            AccountAction = Handlebars.Compile(File.ReadAllText(Path.Join(resourcesPath, "newsletter-account-action-content.html")));
-            WeeklyContent = Handlebars.Compile(File.ReadAllText(Path.Join(resourcesPath, "newsletter-weekly-content.html")));
-            DailyContent = Handlebars.Compile(File.ReadAllText(Path.Join(resourcesPath, "newsletter-daily-content.html")));
-            AdminContent = Handlebars.Compile(File.ReadAllText(Path.Join(resourcesPath, "newsletter-admin-content.html")));
+            _resourcesPath = Path.GetFullPath(Path.Join(env.ContentRootPath, "..", "TechHub.Infrastructure", "Data", "Resources"));
         }
         else
         {
-            Shell = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-template.html"));
-            SubscriberFooter = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-subscriber-footer.html"));
-            AccountAction = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-account-action-content.html"));
-            WeeklyContent = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-weekly-content.html"));
-            DailyContent = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-daily-content.html"));
-            AdminContent = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-admin-content.html"));
+            _shell = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-template.html"));
+            _subscriberFooter = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-subscriber-footer.html"));
+            _accountAction = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-account-action-content.html"));
+            _weeklyContent = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-weekly-content.html"));
+            _dailyContent = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-daily-content.html"));
+            _adminContent = Handlebars.Compile(LoadEmbeddedHtml("TechHub.Infrastructure.Data.Resources.newsletter-admin-content.html"));
         }
     }
 

--- a/src/TechHub.Infrastructure/Services/Newsletter/NewsletterTemplateProvider.cs
+++ b/src/TechHub.Infrastructure/Services/Newsletter/NewsletterTemplateProvider.cs
@@ -9,6 +9,9 @@ namespace TechHub.Infrastructure.Services.Newsletter;
 /// Injected into <see cref="NewsletterService"/> so templates are not recompiled
 /// per DI scope.
 /// </summary>
+/// <remarks>
+/// In development, templates are reloaded from disk (and recompiled) on each access to enable live editing.
+/// </remarks>
 public sealed class NewsletterTemplateProvider
 {
     private readonly IHostEnvironment _env;

--- a/src/TechHub.Web/Components/Pages/Admin/AdminNewsletter.razor
+++ b/src/TechHub.Web/Components/Pages/Admin/AdminNewsletter.razor
@@ -88,6 +88,8 @@
                     <th>Weekly sections</th>
                     <th>Daily sections</th>
                     <th>Confirmed</th>
+                    <th>Last daily</th>
+                    <th>Last weekly</th>
                     <th>Actions</th>
                 </tr>
             </thead>
@@ -100,6 +102,8 @@
                         <td>@string.Join(", ", subscriber.WeeklySections)</td>
                         <td>@string.Join(", ", subscriber.DailySections)</td>
                         <td>@(subscriber.IsConfirmed ? "✓" : "✗")</td>
+                        <td class="admin-cell-send-status">@RenderSendStatus(subscriber.LastDailySentAt, subscriber.LastDailySucceeded)</td>
+                        <td class="admin-cell-send-status">@RenderSendStatus(subscriber.LastWeeklySentAt, subscriber.LastWeeklySucceeded)</td>
                         <td>
                             <button class="admin-link-btn" @onclick="() => StartEdit(subscriber)">Edit</button>
                             <button class="admin-link-btn admin-link-btn-danger" @onclick="() => DeleteAsync(subscriber.Id)">Delete</button>
@@ -359,4 +363,11 @@
                 .Select(x => x.ToLowerInvariant())
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
+
+    private static string RenderSendStatus(DateTimeOffset? sentAt, bool? succeeded) =>
+        sentAt is null
+            ? "—"
+            : succeeded == true
+                ? $"✓ {DateHelper.FormatTimestamp(sentAt.Value)}"
+                : $"✗ {DateHelper.FormatTimestamp(sentAt.Value)}";
 }

--- a/src/TechHub.Web/Components/Pages/Admin/AdminNewsletter.razor
+++ b/src/TechHub.Web/Components/Pages/Admin/AdminNewsletter.razor
@@ -16,8 +16,7 @@
             <p class="admin-page-subtitle">Manage subscribers, remove bot signups, and trigger sends</p>
         </div>
         <div class="admin-actions">
-            <button class="btn" @onclick='() => TriggerSendAsync("roundup")' disabled="@_sending">@(_sending ? "Triggering…" : "▶ Send Roundup")</button>
-            <button class="btn" @onclick='() => TriggerSendAsync("daily")' disabled="@_sending">@(_sending ? "Triggering…" : "▶ Send Daily")</button>
+
             <button class="btn-secondary" @onclick="RefreshAsync" disabled="@_loading">@(_loading ? "Refreshing…" : "⟳ Refresh")</button>
         </div>
     </div>
@@ -59,8 +58,8 @@
         <div class="admin-filter-group">
             <label class="admin-label">&nbsp;</label>
             <div style="display:flex;gap:0.5rem;">
-                <button class="btn-secondary" @onclick='() => TriggerTestSendAsync("weekly")' disabled="@(string.IsNullOrWhiteSpace(_testEmail) || _testSections.Count == 0)">▶ Test Weekly</button>
-                <button class="btn-secondary" @onclick='() => TriggerTestSendAsync("daily")' disabled="@(string.IsNullOrWhiteSpace(_testEmail) || _testSections.Count == 0)">▶ Test Daily</button>
+                <button class="btn" @onclick='() => TriggerTestSendAsync("weekly")' disabled="@(string.IsNullOrWhiteSpace(_testEmail) || _testSections.Count == 0)">▶ Test Weekly</button>
+                <button class="btn" @onclick='() => TriggerTestSendAsync("daily")' disabled="@(string.IsNullOrWhiteSpace(_testEmail) || _testSections.Count == 0)">▶ Test Daily</button>
             </div>
         </div>
     </div>
@@ -183,8 +182,7 @@
     private readonly HashSet<string> _testSections = [];
     private string? _search;
     private string? _confirmedFilter;
-    private string? _testEmail;
-    private bool _sending;
+    private string? _testEmail = "whistler112@gmail.com";
     private bool _loading;
     private string? _message;
     private bool _isError;
@@ -223,6 +221,10 @@
             if (_sections.Count == 0)
             {
                 _sections = await Api.GetNewsletterSectionsAsync() ?? [];
+                foreach (var section in _sections)
+                {
+                    _testSections.Add(section.Name);
+                }
             }
         }
         catch (OperationCanceledException)
@@ -237,28 +239,6 @@
         finally
         {
             _loading = false;
-        }
-    }
-
-    private async Task TriggerSendAsync(string kind)
-    {
-        var normalizedKind = string.Equals(kind?.Trim(), "daily", StringComparison.OrdinalIgnoreCase) ? "daily" : "roundup";
-        try
-        {
-            _sending = true;
-            _message = null;
-            await Api.TriggerNewsletterAsync(normalizedKind);
-            _message = $"Newsletter {normalizedKind} send triggered.";
-            _isError = false;
-        }
-        catch (HttpRequestException ex)
-        {
-            _message = ex.Message;
-            _isError = true;
-        }
-        finally
-        {
-            _sending = false;
         }
     }
 

--- a/tests/TechHub.Infrastructure.Tests/Repositories/NewsletterSubscriberRepositoryTests.cs
+++ b/tests/TechHub.Infrastructure.Tests/Repositories/NewsletterSubscriberRepositoryTests.cs
@@ -119,6 +119,67 @@ public class NewsletterSubscriberRepositoryTests : IClassFixture<DatabaseFixture
     }
 
     [Fact]
+    public async Task RecordSubscriberSendAsync_Daily_UpdatesLastDailyStatus()
+    {
+        // Arrange
+        const string Email = "send-status-daily@example.com";
+        await _sut.UpsertSubscriberAsync(Email, null, [], ["ai"], TestContext.Current.CancellationToken);
+        await _sut.ConfirmSubscriberAsync(Email, TestContext.Current.CancellationToken);
+
+        // Act
+        await _sut.RecordSubscriberSendAsync(Email, isWeekly: false, succeeded: true, TestContext.Current.CancellationToken);
+
+        // Assert
+        var subscriber = await _sut.GetSubscriberByEmailAsync(Email, TestContext.Current.CancellationToken);
+        subscriber.Should().NotBeNull();
+        subscriber!.LastDailySentAt.Should().NotBeNull();
+        subscriber.LastDailySucceeded.Should().BeTrue();
+        subscriber.LastWeeklySentAt.Should().BeNull();
+        subscriber.LastWeeklySucceeded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RecordSubscriberSendAsync_Weekly_UpdatesLastWeeklyStatus()
+    {
+        // Arrange
+        const string Email = "send-status-weekly@example.com";
+        await _sut.UpsertSubscriberAsync(Email, null, ["ai"], [], TestContext.Current.CancellationToken);
+        await _sut.ConfirmSubscriberAsync(Email, TestContext.Current.CancellationToken);
+
+        // Act
+        await _sut.RecordSubscriberSendAsync(Email, isWeekly: true, succeeded: false, TestContext.Current.CancellationToken);
+
+        // Assert
+        var subscriber = await _sut.GetSubscriberByEmailAsync(Email, TestContext.Current.CancellationToken);
+        subscriber.Should().NotBeNull();
+        subscriber!.LastWeeklySentAt.Should().NotBeNull();
+        subscriber.LastWeeklySucceeded.Should().BeFalse();
+        subscriber.LastDailySentAt.Should().BeNull();
+        subscriber.LastDailySucceeded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSubscribersAsync_IncludesSendStatus_WhenPresent()
+    {
+        // Arrange
+        const string Email = "send-status-admin@example.com";
+        await _sut.UpsertSubscriberAsync(Email, null, ["ai"], ["ai"], TestContext.Current.CancellationToken);
+        await _sut.ConfirmSubscriberAsync(Email, TestContext.Current.CancellationToken);
+        await _sut.RecordSubscriberSendAsync(Email, isWeekly: false, succeeded: true, TestContext.Current.CancellationToken);
+        await _sut.RecordSubscriberSendAsync(Email, isWeekly: true, succeeded: false, TestContext.Current.CancellationToken);
+
+        // Act
+        var subscribers = await _sut.GetSubscribersAsync(search: "send-status-admin", ct: TestContext.Current.CancellationToken);
+
+        // Assert
+        var found = subscribers.Should().ContainSingle(s => s.Email == Email).Which;
+        found.LastDailySentAt.Should().NotBeNull();
+        found.LastDailySucceeded.Should().BeTrue();
+        found.LastWeeklySentAt.Should().NotBeNull();
+        found.LastWeeklySucceeded.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task GetDailyReportStatsAsync_ReturnsNonNegativeCounts()
     {
         var stats = await _sut.GetDailyReportStatsAsync(TestContext.Current.CancellationToken);

--- a/tests/TechHub.Infrastructure.Tests/Services/NewsletterServiceTests.cs
+++ b/tests/TechHub.Infrastructure.Tests/Services/NewsletterServiceTests.cs
@@ -317,17 +317,37 @@ public class NewsletterServiceTests : IClassFixture<DatabaseFixture<NewsletterSe
             "daily email sections should follow configured website order");
     }
 
+    [Fact]
+    public async Task SendAdminStatusReportAsync_WhenNoFailures_ReturnsFalseWithoutSendingEmail()
+    {
+        var day = new DateOnly(2026, 5, 28);
+        const string TargetKey = "2026-05-28";
+        await _fixture.Connection.ExecuteAsync("""
+            DELETE FROM newsletter_send_log WHERE send_kind = 'admin-status' AND target_key = @TargetKey
+            """, new { TargetKey });
+
+        var emailSender = new Mock<IEmailSender>(MockBehavior.Strict);
+        var sut = CreateService(adminReportEmailAddress: "admin@example.com", emailSender: emailSender.Object);
+
+        var result = await sut.SendAdminStatusReportAsync(day, TestContext.Current.CancellationToken);
+
+        result.Should().BeFalse();
+        emailSender.VerifyNoOtherCalls();
+    }
+
     private NewsletterService CreateService(
         IContentRepository? contentRepository = null,
         IEmailSender? emailSender = null,
-        string unsubscribeSecret = "test-secret")
+        string unsubscribeSecret = "test-secret",
+        string adminReportEmailAddress = "")
     {
         var options = Options.Create(new NewsletterOptions
         {
             Endpoint = "https://invalid.communication.azure.com/",
             SenderAddress = "DoNotReply@example.azurecomm.net",
             WebsiteBaseUrl = "https://tech.hub.ms",
-            UnsubscribeSecret = unsubscribeSecret
+            UnsubscribeSecret = unsubscribeSecret,
+            AdminReportEmailAddress = adminReportEmailAddress
         });
 
         contentRepository ??= new Mock<IContentRepository>(MockBehavior.Loose).Object;


### PR DESCRIPTION
## Summary

Admins had no visibility into whether individual newsletter subscribers successfully received their last daily or weekly email. The newsletter email template also had email-client compatibility issues that caused rendering problems in Outlook and other clients. Additionally, the admin daily status report was being sent even when there were no failures, creating noise. Finally, the Azure AD app registration was rotated to a new tenant and client ID.

## Changes

### Newsletter send status tracking
- New DB migration (#047) adds last_daily_sent_at, last_daily_succeeded, last_weekly_sent_at, and last_weekly_succeeded columns to 
ewsletter_subscribers
- NewsletterSubscriber model and INewsletterSubscriberRepository extended with the new fields and a RecordSubscriberSendAsync method
- NewsletterService records send outcome per subscriber after every send attempt, including in the error catch path
- Admin newsletter page now shows **Last daily** and **Last weekly** columns (✓/✗ + timestamp)

### Email template overhaul
- 
ewsletter-template.html rewritten with a proper email-client CSS reset (MSO conditional comments, Outlook table fixes, Apple Mail / Gmail normalisations)
- NewsletterTemplateProvider now live-reloads templates from disk in development so HTML changes are visible without a restart
- Weekly email CTA uses sectionTag (short form) instead of sectionTitle; roundups sorted alphabetically by title

### Admin daily report
- Report is now suppressed when there are no failures — no more noise-only emails

### Infrastructure / scripts
- Prod Azure AD tenant ID and client ID updated to new app registration
- OIDC script app ID updated; messaging clarified (no AZURE_CREDENTIALS secret needed)
- Failed-requests alert now includes all errors (HTTP 499 and ResultCode=0 are no longer excluded — a burst of client disconnects can indicate the app is too slow)
- Documentation updated to match
